### PR TITLE
Add debug logs to functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ blsful = "2.4"
 subtle = "2.4.1"
 uint-zigzag = { version = "0.2", features = ["std"] }
 zeroize = "1"
+log = "0.4.20"
 
 [dev-dependencies]
 maplit = "1"
 serde_cbor = "0.11"
 sha2 = "0.10"
+env_logger = "0.9"

--- a/src/credential/schema.rs
+++ b/src/credential/schema.rs
@@ -4,6 +4,7 @@ use crate::{random_string, utils::*, CredxResult};
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use uint_zigzag::Uint;
+use log::debug;
 
 /// A credential schema
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -62,14 +63,16 @@ impl CredentialSchema {
             }
         }
         let blind_claims = blind_claims.iter().map(|b| b.to_string()).collect();
-        Ok(Self {
+        let schema = Self {
             id,
             blind_claims,
             claims,
             claim_indices,
             label: label.map(|l| l.to_string()),
             description: description.map(|d| d.to_string()),
-        })
+        };
+        debug!("Credential Schema: {}", serde_json::to_string_pretty(&schema).unwrap());
+        Ok(schema)
     }
     /// Add data to the transcript
     pub fn add_challenge_contribution(&self, transcript: &mut merlin::Transcript) {

--- a/src/credential/schema.rs
+++ b/src/credential/schema.rs
@@ -2,9 +2,9 @@ use crate::claim::*;
 use crate::error::Error;
 use crate::{random_string, utils::*, CredxResult};
 use indexmap::IndexSet;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use uint_zigzag::Uint;
-use log::debug;
 
 /// A credential schema
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -71,7 +71,10 @@ impl CredentialSchema {
             label: label.map(|l| l.to_string()),
             description: description.map(|d| d.to_string()),
         };
-        debug!("Credential Schema: {}", serde_json::to_string_pretty(&schema).unwrap());
+        debug!(
+            "Credential Schema: {}",
+            serde_json::to_string_pretty(&schema).unwrap()
+        );
         Ok(schema)
     }
     /// Add data to the transcript

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -8,9 +8,9 @@ use crate::knox::{
 };
 use crate::{random_string, CredxResult};
 use blsful::{inner_types::*, *};
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use log::debug;
 
 /// An issuer of a credential
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -165,7 +165,10 @@ impl Issuer {
                 revocation_index: revocation_element_index,
             },
         };
-        debug!("Signed Credential: {}", serde_json::to_string_pretty(&credential_bundle).unwrap());
+        debug!(
+            "Signed Credential: {}",
+            serde_json::to_string_pretty(&credential_bundle).unwrap()
+        );
         Ok(credential_bundle)
     }
 
@@ -266,7 +269,10 @@ impl Issuer {
                 revocation_label,
             },
         };
-        debug!("Blind Signed Credential: {}", serde_json::to_string_pretty(&blind_credential_bundle).unwrap());
+        debug!(
+            "Blind Signed Credential: {}",
+            serde_json::to_string_pretty(&blind_credential_bundle).unwrap()
+        );
         Ok(blind_credential_bundle)
     }
 

--- a/src/presentation/create.rs
+++ b/src/presentation/create.rs
@@ -1,4 +1,5 @@
 use super::*;
+use log::debug;
 
 impl Presentation {
     /// Create a new presentation composed of 1 to many proofs
@@ -206,11 +207,12 @@ impl Presentation {
             let proof = builder.gen_proof(challenge);
             proofs.insert(proof.id().clone(), proof);
         }
-
-        Ok(Self {
+        let presentation = Self {
             proofs,
             challenge,
             disclosed_messages,
-        })
+        };
+        debug!("Presentation: {}", serde_json::to_string(&presentation).unwrap());
+        Ok(presentation)
     }
 }

--- a/src/presentation/create.rs
+++ b/src/presentation/create.rs
@@ -212,7 +212,10 @@ impl Presentation {
             challenge,
             disclosed_messages,
         };
-        debug!("Presentation: {}", serde_json::to_string(&presentation).unwrap());
+        debug!(
+            "Presentation: {}",
+            serde_json::to_string(&presentation).unwrap()
+        );
         Ok(presentation)
     }
 }

--- a/src/presentation/schema.rs
+++ b/src/presentation/schema.rs
@@ -1,6 +1,7 @@
 use crate::random_string;
 use crate::{statement::Statements, utils::*};
 use indexmap::IndexMap;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use uint_zigzag::Uint;
 
@@ -22,7 +23,9 @@ impl PresentationSchema {
     pub fn new(statements: &[Statements]) -> Self {
         let id = random_string(16, rand::thread_rng());
         let statements = statements.iter().map(|s| (s.id(), s.clone())).collect();
-        Self { id, statements }
+        let presentation_schema = Self { id, statements };
+        debug!("Presentation Schema: {}", serde_json::to_string_pretty(&presentation_schema).unwrap());
+        presentation_schema
     }
 
     /// Add challenge contribution

--- a/src/presentation/schema.rs
+++ b/src/presentation/schema.rs
@@ -24,7 +24,10 @@ impl PresentationSchema {
         let id = random_string(16, rand::thread_rng());
         let statements = statements.iter().map(|s| (s.id(), s.clone())).collect();
         let presentation_schema = Self { id, statements };
-        debug!("Presentation Schema: {}", serde_json::to_string_pretty(&presentation_schema).unwrap());
+        debug!(
+            "Presentation Schema: {}",
+            serde_json::to_string_pretty(&presentation_schema).unwrap()
+        );
         presentation_schema
     }
 

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -312,6 +312,7 @@ fn test_presentation_1_credential_alter_revealed_message_fails() -> CredxResult<
 
 #[test]
 fn blind_sign_request() {
+    setup();
     let res = test_blind_sign_request();
     assert!(res.is_ok(), "{:?}", res);
 }

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -24,8 +24,13 @@ use regex::Regex;
 use sha2;
 use std::time::Instant;
 
+fn setup() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 #[test]
 fn presentation_1_credential_works() {
+    setup();
     let res = test_presentation_1_credential_works();
     assert!(res.is_ok(), "{:?}", res);
 }


### PR DESCRIPTION
In order to view the logs in the console, run the command:
`RUST_LOG=debug cargo test --test flow -- --nocapture --test-threads=1` to run the entire tests or 
`RUST_LOG=debug cargo test --test flow <test_name> -- --nocapture --test-threads=1` to run the `test_name` test.