### PR TITLE
Tests combining reveal and equality, and fixes to issues they demonstrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ zeroize = "1"
 log = "0.4.20"
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 maplit = "1"
 serde_cbor = "0.11"
 sha2 = "0.10"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,4 @@
+
+This project contains contributions subject to:
+
+Copyright © 2024, Oracle and/or its affiliates.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /// Errors created by this library
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Bad Credential Schema
     InvalidCredentialSchema,

--- a/src/knox/ps/pok_signature_proof.rs
+++ b/src/knox/ps/pok_signature_proof.rs
@@ -149,7 +149,9 @@ impl ProofOfSignatureKnowledge for PokSignatureProof {
             }
             let message = self
                 .proof
-                .get(i + 2)
+                // + 2 because ProofOfSignatureKnowledgeContribution.commit adds
+                // two secrets before adding secrets for attributes
+                .get(i + 2 - j)
                 .ok_or(Error::General("invalid proof"))?;
             hidden.insert(i, *message);
         }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -282,6 +282,15 @@ impl Presentation {
                 let ix1 = statement.get_claim_index(id1);
                 let map1 = proof_messages.get(id1).unwrap().clone();
                 let map2 = proof_messages.get_mut(id2).unwrap();
+                // NOTE: other unexpected combinations could be checked too,
+                // e.g., one ProofSpecificBlinding, one ExternalBlinding
+                if matches!(map1[ix1], ProofMessage::Revealed(_))
+                    || matches!(map2[ix2], ProofMessage::Revealed(_))
+                {
+                    return Err(Error::InvalidClaimData(
+                        "revealed claim cannot be used with equality proof",
+                    ));
+                }
                 map2[ix2] = map1[ix1];
             }
         }

--- a/tests/equality-and-reveal.rs
+++ b/tests/equality-and-reveal.rs
@@ -20,21 +20,21 @@ mod reveal_and_equality_tests {
     // -------------------------------------------------------------------------
     // Setup some names for readability
 
-    const SSN_IX:  usize = 0;
+    const SSN_IX: usize = 0;
     const NAME_IX: usize = 1;
 
-    const ID_LBL:   &str = "id";
+    const ID_LBL: &str = "id";
     const NAME_LBL: &str = "name";
-    const SSN_LBL:  &str = "social-security-number";
-    const SSN:      &str = "123-12-1234";
-    const SS_ID_A:  &str = "SignatureStatement ID A";
-    const SS_ID_B:  &str = "SignatureStatement ID B";
+    const SSN_LBL: &str = "social-security-number";
+    const SSN: &str = "123-12-1234";
+    const SS_ID_A: &str = "SignatureStatement ID A";
+    const SS_ID_B: &str = "SignatureStatement ID B";
 
     type DisclosureReqs = BTreeSet<String>;
 
     lazy_static! {
         static ref REV_NONE: DisclosureReqs = btreeset! {};
-        static ref REV_SSN:  DisclosureReqs = btreeset! {SSN_LBL.to_string()};
+        static ref REV_SSN: DisclosureReqs = btreeset! {SSN_LBL.to_string()};
     }
 
     /* -------------------------------------------------------------------------
@@ -166,11 +166,11 @@ mod reveal_and_equality_tests {
     type Disclosures = IndexMap<String, IndexMap<String, ClaimData>>;
 
     fn run_test(
-        issuer_public:  &IssuerPublic,
-        mut issuer:     Issuer,
-        name_b:         &str,
-        reveal_a:       &DisclosureReqs,
-        reveal_b:       &DisclosureReqs,
+        issuer_public: &IssuerPublic,
+        mut issuer: Issuer,
+        name_b: &str,
+        reveal_a: &DisclosureReqs,
+        reveal_b: &DisclosureReqs,
         equality_index: Option<usize>,
     ) -> CredxResult<Disclosures> {
         const CRED_ID_A: &str = "91742856-6eda-45fb-a709-d22ebb5ec8a5";
@@ -301,7 +301,7 @@ mod reveal_and_equality_tests {
     }
 
     fn validate_disclosures(
-        r:     Result<Disclosures, Error>,
+        r: Result<Disclosures, Error>,
         req_a: &DisclosureReqs,
         req_b: &DisclosureReqs,
     ) {

--- a/tests/equality-and-reveal.rs
+++ b/tests/equality-and-reveal.rs
@@ -202,26 +202,32 @@ mod reveal_and_equality_tests {
         let mut nonce = [0u8; 16];
         thread_rng().fill_bytes(&mut nonce);
 
-        let credentials = indexmap! {
-            sig_st_a.id.clone() => credential_a.credential.into(),
-            sig_st_b.id.clone() => credential_b.credential.into() };
+        #[cfg_attr(rustfmt, rustfmt_skip)]
+        // when possible: #[rustmt::skip]
+        {
+            let credentials = indexmap! {
+                    sig_st_a.id.clone() => credential_a.credential.into(),
+                    sig_st_b.id.clone() => credential_b.credential.into()
+            };
 
-        let presentation_schema: PresentationSchema = match equality_index {
-            None => PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into()]),
-            Some(i) => {
-                let eq_st = EqualityStatement {
-                    id: random_string(16, rand::thread_rng()),
-                    ref_id_claim_index: indexmap! {
-                        sig_st_a.id.clone() => i,
-                        sig_st_b.id.clone() => i },
-                };
-                PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()])
-            }
-        };
+            let presentation_schema: PresentationSchema = match equality_index {
+                None => PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into()]),
+                Some(i) => {
+                    let eq_st = EqualityStatement {
+                        id: random_string(16, rand::thread_rng()),
+                        ref_id_claim_index: indexmap! {
+                            sig_st_a.id.clone() => i,
+                            sig_st_b.id.clone() => i
+                        },
+                    };
+                    PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()])
+                }
+            };
 
-        let presentation = Presentation::create(&credentials, &presentation_schema, &nonce)?;
-        presentation.verify(&presentation_schema, &nonce)?;
-        Ok(presentation.disclosed_messages)
+            let presentation = Presentation::create(&credentials, &presentation_schema, &nonce)?;
+            presentation.verify(&presentation_schema, &nonce)?;
+            Ok(presentation.disclosed_messages)
+        }
     }
 
     fn setup_issuer() -> (IssuerPublic, Issuer) {

--- a/tests/equality-and-reveal.rs
+++ b/tests/equality-and-reveal.rs
@@ -1,0 +1,360 @@
+#[cfg(test)]
+mod reveal_and_equality_tests {
+    use credx::claim::ClaimData;
+    use credx::claim::{ClaimType, ClaimValidator, HashedClaim, RevocationClaim};
+    use credx::credential::{ClaimSchema, CredentialSchema};
+    use credx::error::Error;
+    use credx::issuer::Issuer;
+    use credx::prelude::IssuerPublic;
+    use credx::presentation::{Presentation, PresentationSchema};
+    use credx::statement::{EqualityStatement, SignatureStatement};
+    use credx::{random_string, CredxResult};
+    use indexmap::{indexmap, IndexMap};
+    use lazy_static::lazy_static;
+    use maplit::btreeset;
+    use rand::thread_rng;
+    use rand_core::RngCore;
+    use std::collections::BTreeSet;
+    use std::fmt::Debug;
+
+    // -------------------------------------------------------------------------
+    // Setup some names for readability
+
+    const SSN_IX:  usize = 0;
+    const NAME_IX: usize = 1;
+
+    const ID_LBL:   &str = "id";
+    const NAME_LBL: &str = "name";
+    const SSN_LBL:  &str = "social-security-number";
+    const SSN:      &str = "123-12-1234";
+    const SS_ID_A:  &str = "SignatureStatement ID A";
+    const SS_ID_B:  &str = "SignatureStatement ID B";
+
+    type DisclosureReqs = BTreeSet<String>;
+
+    lazy_static! {
+        static ref REV_NONE: DisclosureReqs = btreeset! {};
+        static ref REV_SSN:  DisclosureReqs = btreeset! {SSN_LBL.to_string()};
+    }
+
+    /* -------------------------------------------------------------------------
+
+    Overview of tests
+    -----------------
+
+    The tests exercise various combinations of equality and reveal requirements.
+
+    run_test creates a simple schema with name and social security claims (in
+    addition to a revocation claim that is required, but not used or relevant to
+    these tests), and creates and Issuer and signs two credentials (using the
+    same Issuer) according to provided parameters.  The name of the first is
+    always Alice and the name of the second is provided by each test to enable
+    testing equal and non-equal examples.
+
+    Test setup
+    ----------
+
+    Each test specifies:
+
+    - the name for the second credential (the name for the first is always Alice)
+    - a set of attributes to reveal from the first credential (REV_NONE requests
+      no attributes to be revealed, and REV_SSN) requests the
+      social-security-number attribute to be revealed)
+    - similarly for attributes to be revealed for the second credential
+    - an optional index for attributes to be subject to equality constraints
+
+    Expected outcome
+    ----------------
+
+    Each test specifies one of
+
+    - Expected success (via validate_disclosures), with a set of attribute
+      values expected to be revealed
+
+    - Expected failure (via assert_matches_error), with an Error specifying a
+      pattern for expected failure. For example, an error matches
+      Error::InvalidClaimData("XYZ") if it is an Error::InvalidClaimData with a
+      string containing XYZ.
+
+    ---------------------------------------------------------------------------- */
+    // Tests
+
+    // Request: reveal first SSN
+    // Expected: verification succeeds, first SSN revealed
+    #[test]
+    fn t00_reveal_ssn_a_no_equality() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "_", &REV_SSN, &REV_NONE, None);
+        validate_disclosures(r, &REV_SSN, &REV_NONE)
+    }
+
+    // Request: reveal first SSN, non-equal names equal
+    // Expected: verification fails due to different names
+    #[test]
+    fn t01_reveal_ssn_a_eq_names_unequal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "Bob", &REV_SSN, &REV_NONE, Some(NAME_IX));
+        assert_matches_error(
+            r,
+            Error::InvalidClaimData("equality statement - claims are not all the same"),
+        );
+    }
+
+    // Request: reveal no attributes, equal names equal
+    // Expected: verification succeeds, no attributes revealed
+    #[test]
+    fn t02_no_reveal_eq_names_equal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "Alice", &REV_NONE, &REV_NONE, Some(NAME_IX));
+        validate_disclosures(r, &REV_NONE, &REV_NONE)
+    }
+
+    // Request: reveal first SSN, equal names equal
+    // Expected: verification succeeds, first SSN revealed
+    #[test]
+    fn t03_reveal_ssn_a_eq_names_equal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "Alice", &REV_SSN, &REV_NONE, Some(NAME_IX));
+        validate_disclosures(r, &REV_SSN, &REV_NONE)
+    }
+
+    // Request: reveal second SSN, equal SSNs equal
+    // Expected: EITHER verification succeeds and second SSN revealed
+    //           OR     presentation creation fails with informative error
+    //                  message that it does not make sense to request equality
+    //                  of revealed attributes
+    #[test]
+    // NOTE: the expected outcome expressed below is that verificaton succeeds
+    // and NO attributes are revealed, and the test is annotated with
+    // should_panic.  Thus, this test failing indicates that verification
+    // succeeded and no attributes were revealed, which is not correct behaviour
+    // according to either of the alternative expected scenarios.
+    #[should_panic]
+    fn t04_reveal_ssn_b_eq_ssns_equal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "_", &REV_NONE, &REV_SSN, Some(SSN_IX));
+        validate_disclosures(r, &REV_NONE, &REV_NONE)
+    }
+
+    // Request: reveal first SSN, equal SSNs equal
+    // Expected: verification fails with informative error
+    #[test]
+    fn t05_reveal_ssn_a_eq_ssns_equal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "_", &REV_SSN, &REV_NONE, Some(SSN_IX));
+        assert_matches_error(
+            r,
+            Error::InvalidClaimData("revealed claim cannot be used with equality proof"),
+        );
+    }
+
+    // Request: reveal second SSN, equal SSNs equal
+    // Expected: verification fails with informative error
+    #[test]
+    fn t06_reveal_ssn_b_eq_ssns_equal() {
+        let (isspub, iss) = setup_issuer();
+        let r = run_test(&isspub, iss, "_", &REV_NONE, &REV_SSN, Some(SSN_IX));
+        assert_matches_error(
+            r,
+            Error::InvalidClaimData("revealed claim cannot be used with equality proof"),
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test setup
+
+    type Disclosures = IndexMap<String, IndexMap<String, ClaimData>>;
+
+    fn run_test(
+        issuer_public:  &IssuerPublic,
+        mut issuer:     Issuer,
+        name_b:         &str,
+        reveal_a:       &DisclosureReqs,
+        reveal_b:       &DisclosureReqs,
+        equality_index: Option<usize>,
+    ) -> CredxResult<Disclosures> {
+        const CRED_ID_A: &str = "91742856-6eda-45fb-a709-d22ebb5ec8a5";
+        let credential_a = issuer.sign_credential(&[
+            HashedClaim::from(SSN.to_string()).into(),
+            HashedClaim::from("Alice").into(),
+            RevocationClaim::from(CRED_ID_A).into(),
+        ])?;
+
+        const CRED_ID_B: &str = "12345678-6eda-45fb-a709-d22ebb5ec8a5";
+        let credential_b = issuer.sign_credential(&[
+            HashedClaim::from(SSN.to_string()).into(),
+            HashedClaim::from(name_b).into(),
+            RevocationClaim::from(CRED_ID_B).into(),
+        ])?;
+
+        let sig_st_a = SignatureStatement {
+            disclosed: reveal_a.clone(),
+            id: SS_ID_A.to_string(),
+            issuer: issuer_public.clone(),
+        };
+
+        let sig_st_b = SignatureStatement {
+            disclosed: reveal_b.clone(),
+            id: SS_ID_B.to_string(),
+            issuer: issuer_public.clone(),
+        };
+
+        let mut nonce = [0u8; 16];
+        thread_rng().fill_bytes(&mut nonce);
+
+        let credentials = indexmap! {
+            sig_st_a.id.clone() => credential_a.credential.into(),
+            sig_st_b.id.clone() => credential_b.credential.into() };
+
+        let presentation_schema: PresentationSchema = match equality_index {
+            None => PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into()]),
+            Some(i) => {
+                let eq_st = EqualityStatement {
+                    id: random_string(16, rand::thread_rng()),
+                    ref_id_claim_index: indexmap! {
+                        sig_st_a.id.clone() => i,
+                        sig_st_b.id.clone() => i },
+                };
+                PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()])
+            }
+        };
+
+        let presentation = Presentation::create(&credentials, &presentation_schema, &nonce)?;
+        presentation.verify(&presentation_schema, &nonce)?;
+        Ok(presentation.disclosed_messages)
+    }
+
+    fn setup_issuer() -> (IssuerPublic, Issuer) {
+        const LABEL: &str = "Test Schema";
+        const DESCRIPTION: &str = "This is a test presentation schema";
+
+        let schema_claims = [
+            ClaimSchema {
+                claim_type: ClaimType::Hashed,
+                label: SSN_LBL.to_string(),
+                print_friendly: true,
+                validators: vec![ClaimValidator::Length {
+                    min: Some(3),
+                    max: Some(u8::MAX as usize),
+                }],
+            },
+            ClaimSchema {
+                claim_type: ClaimType::Hashed,
+                label: NAME_LBL.to_string(),
+                print_friendly: true,
+                validators: vec![ClaimValidator::Length {
+                    min: None,
+                    max: Some(u8::MAX as usize),
+                }],
+            },
+            ClaimSchema {
+                claim_type: ClaimType::Revocation,
+                label: ID_LBL.to_string(),
+                print_friendly: false,
+                validators: vec![],
+            },
+        ];
+
+        let cred_schema =
+            CredentialSchema::new(Some(LABEL), Some(DESCRIPTION), &[], &schema_claims).unwrap();
+        Issuer::new(&cred_schema)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test-specific test utilities
+
+    fn validate_disclosure(d: &Disclosures, id: &str, req: &DisclosureReqs) {
+        match d.get(id) {
+            None => panic!("No disclosures for {:?} in {:?}", id, d),
+            Some(disclosures_for_id) => {
+                // First check that we got the requested number of disclosures
+                assert_eq!(req.len(), disclosures_for_id.len(),
+                         "number of disclosures expected from {:?} does not equal number received in {:?}",
+                         d, disclosures_for_id);
+                // Then validate the disclosures received.
+                // NOTE: this is not very general, as it assumes req contains at most one value, which is
+                // SSN_LBL ("social-security-number") if it exists, and that the expected value is SSN
+                let _: Vec<_> = req
+                    .iter()
+                    .map(|k| {
+                        assert_eq!(*k, SSN_LBL.to_string());
+                        match disclosures_for_id.get(k) {
+                            None => panic!(
+                                "Expected disclosure for {:?} not found for {:?} in {:?}",
+                                k, id, d
+                            ),
+                            Some(ClaimData::Hashed(v)) => {
+                                assert_eq!(HashedClaim::from(SSN.to_string()), *v)
+                            }
+                            Some(cd) => panic!("Expected HashedClaim, got {:?}", cd),
+                        }
+                    })
+                    .collect();
+            }
+        }
+    }
+
+    fn validate_disclosures(
+        r:     Result<Disclosures, Error>,
+        req_a: &DisclosureReqs,
+        req_b: &DisclosureReqs,
+    ) {
+        match &r {
+            Err(e) => panic!(
+                "Expected successful verification, but received error: {:?}",
+                e
+            ),
+            Ok(d) => {
+                validate_disclosure(d, SS_ID_A, req_a);
+                validate_disclosure(d, SS_ID_B, req_b);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // General test utilities
+    // These utilities could be moved somewhere more general for use in other
+    // tests
+    macro_rules! match_err_with_one_string {
+        ($constr:path, $s:expr, $expected:expr) => {
+            match $expected {
+                $constr(exp_str) => assert!(
+                    $s.contains(exp_str),
+                    "error {:?} does not match expected {:?}",
+                    $constr($s),
+                    $expected
+                ),
+                _ => panic!(
+                    "error {:?} does not match expected {:?}",
+                    $constr($s),
+                    $expected
+                ),
+            }
+        };
+    }
+
+    fn assert_matches_error_detail(e: Error, expected: Error) {
+        match e {
+            Error::InvalidClaimData(s) => {
+                match_err_with_one_string!(Error::InvalidClaimData, s, expected)
+            }
+            Error::General(s) => match_err_with_one_string!(Error::General, s, expected),
+            err => {
+                if err != expected {
+                    panic!("error {:?} does not match expected {:?}", err, expected)
+                }
+            }
+        }
+    }
+
+    fn assert_matches_error<R: Debug>(r: Result<R, Error>, expected: Error) {
+        match r {
+            Ok(_) => assert!(
+                r.is_err(),
+                "succeeded but expected error matching {:?}",
+                expected
+            ),
+            Err(e) => assert_matches_error_detail(e, expected),
+        }
+    }
+}


### PR DESCRIPTION
This PR first adds some tests that exercise interactions between Selective Disclosure and Equality requirements.  It also includes some testing machinery that may be of independent value.  Some of the tests currently fail (in some cases relative to what we think the desired behaviour is).  This PR then adds two small changes that make the tests pass.

Here is a summary of how the tests illustrate the issues and the outcome of the fix:

1. Test `t03_reveal_ssn_a_eq_names_equal` requests equality of two equal attributes and disclosure of one attribute that is not subject to the equality constraint.  Verification should succeed, but it currently fails with `InvalidPresentationData`.
1. Test `t04_reveal_ssn_b_eq_ssns_equal` requests an attribute to be revealed which is also subject to an equality constraint.  In our opinion, EITHER presentation creation should fail with an informative error message that this scenario is not allowed (it doesn't make sense to prove equality in zero knowledge if revealing the attribute anyway) OR creation and verification of the presentation should succeed, and the requested attribute should be revealed.  The current behaviour is that creation and verification succeed, but no attributes are revealed.  We prefer the first option, as expressed in the expectations for `t05_reveal_ssn_a_eq_ssns_equal` and `t06_reveal_ssn_b_eq_ssns_equal`, described next.
1. Tests `t05_reveal_ssn_a_eq_ssns_equal` and `t06_reveal_ssn_b_eq_ssns_equal` test variations on revealing an attribute that is subject to an equality constraint, expecting failure of presentation creation with an informative error message.  They currently both fail, but in different ways: `t05_reveal_ssn_a_eq_ssns_equal` fails  with `InvalidPresentationData` and `t06_reveal_ssn_b_eq_ssns_equal` appears to succeed, but (as shown by test `t04_reveal_ssn_b_eq_ssns_equal`, which has the same test setup but different expectations) does not reveal the requested attribute.

Details of tests follow.

----------

It's best to run the tests single-threaded for consistent readability of output:

```
cargo test reveal_and_equality_tests -- --test-threads=1
```

### Overview of tests
We create a simple schema with `name` and `social security` claims (in addition to a revocation claim that is required, but not used or relevant to these tests).  The tests exercise various combinations of equality and reveal requirements.  Each test creates two credentials (using the same Issuer).  The name of the first is always `Alice`, the name of the second is provided by each test to enable testing equal and non-equal examples.

#### Test setup
Each test specifies:
- the name for the second credential (the name for the first is always `Alice`)
- a set of attributes to reveal from the first credential (`REV_NONE` requests no attributes to be revealed, and `REV_SSN`) requests the `social-security-number` attribute to be revealed)
- similarly for attributes to be revealed for the second credential
- an optional index for attributes to be subject to equality constraints 

#### Expected outcome
Each test specifies one of
- Expected success, with a set of attribute values expected to be revealed
- Expected failure, with an `Error` specifying a pattern for expected failure.  For example, an error matches `Error::InvalidClaimData("XYZ")` if it is an `Error::InvalidClaimData` with a string containing `XYZ`.

### Full test output before fixes
```
$ cargo test reveal_and_equality_tests -- --test-threads=1
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/debug/deps/credx-0d867c53b39d4fed)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s

     Running tests/equality-and-reveal.rs (target/debug/deps/equality_and_reveal-cd78ea2fc82a23fb)

running 7 tests
test reveal_and_equality_tests::t00_reveal_ssn_a_no_equality ... ok
test reveal_and_equality_tests::t01_reveal_ssn_a_eq_names_unequal ... ok
test reveal_and_equality_tests::t02_no_reveal_eq_names_equal ... ok
test reveal_and_equality_tests::t03_reveal_ssn_a_eq_names_equal ... FAILED
test reveal_and_equality_tests::t04_reveal_ssn_b_eq_ssns_equal - should panic ... FAILED
test reveal_and_equality_tests::t05_reveal_ssn_a_eq_ssns_equal ... FAILED
test reveal_and_equality_tests::t06_reveal_ssn_b_eq_ssns_equal ... FAILED

failures:

---- reveal_and_equality_tests::t03_reveal_ssn_a_eq_names_equal stdout ----
thread 'reveal_and_equality_tests::t03_reveal_ssn_a_eq_names_equal' panicked at 'Expected successful verification, but received error: InvalidPresentationData', tests/equality-and-reveal.rs:298:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- reveal_and_equality_tests::t04_reveal_ssn_b_eq_ssns_equal stdout ----
note: test did not panic as expected
---- reveal_and_equality_tests::t05_reveal_ssn_a_eq_ssns_equal stdout ----
thread 'reveal_and_equality_tests::t05_reveal_ssn_a_eq_ssns_equal' panicked at 'error InvalidPresentationData does not match expected InvalidClaimData("revealed claim cannot be used with equality proof")', tests/equality-and-reveal.rs:338:21

---- reveal_and_equality_tests::t06_reveal_ssn_b_eq_ssns_equal stdout ----
thread 'reveal_and_equality_tests::t06_reveal_ssn_b_eq_ssns_equal' panicked at 'succeeded but expected error matching InvalidClaimData("revealed claim cannot be used with equality proof")', tests/equality-and-reveal.rs:346:22


failures:
    reveal_and_equality_tests::t03_reveal_ssn_a_eq_names_equal
    reveal_and_equality_tests::t04_reveal_ssn_b_eq_ssns_equal
    reveal_and_equality_tests::t05_reveal_ssn_a_eq_ssns_equal
    reveal_and_equality_tests::t06_reveal_ssn_b_eq_ssns_equal

test result: FAILED. 3 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s

error: test failed, to rerun pass `--test equality-and-reveal`
```
### Full test output after fixes
```
$ cargo test reveal_and_equality_tests -- --test-threads=1
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/debug/deps/credx-0d867c53b39d4fed)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s

     Running tests/equality-and-reveal.rs (target/debug/deps/equality_and_reveal-cd78ea2fc82a23fb)

running 7 tests
test reveal_and_equality_tests::t00_reveal_ssn_a_no_equality ... ok
test reveal_and_equality_tests::t01_reveal_ssn_a_eq_names_unequal ... ok
test reveal_and_equality_tests::t02_no_reveal_eq_names_equal ... ok
test reveal_and_equality_tests::t03_reveal_ssn_a_eq_names_equal ... ok
test reveal_and_equality_tests::t04_reveal_ssn_b_eq_ssns_equal - should panic ... ok
test reveal_and_equality_tests::t05_reveal_ssn_a_eq_ssns_equal ... ok
test reveal_and_equality_tests::t06_reveal_ssn_b_eq_ssns_equal ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s

     Running tests/flow.rs (target/debug/deps/flow-a8a858c47eefcd38)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
```
