### PR TITLE
Enable specifying an ID when creating a PresentationSchema

### DIFF
--- a/src/presentation/schema.rs
+++ b/src/presentation/schema.rs
@@ -19,9 +19,15 @@ pub struct PresentationSchema {
 }
 
 impl PresentationSchema {
-    /// Create a new presentation schema
+    /// Create a new presentation schema with random id
     pub fn new(statements: &[Statements]) -> Self {
         let id = random_string(16, rand::thread_rng());
+        Self::new_with_id(statements, &id)
+    }
+
+    /// Create a new presentation schema with given id
+    pub fn new_with_id(statements: &[Statements], pres_schema_id: &str) -> Self {
+        let id = pres_schema_id.into();
         let statements = statements.iter().map(|s| (s.id(), s.clone())).collect();
         let presentation_schema = Self { id, statements };
         debug!(

--- a/tests/equality-and-reveal.rs
+++ b/tests/equality-and-reveal.rs
@@ -209,14 +209,21 @@ mod reveal_and_equality_tests {
                     sig_st_a.id.clone() => credential_a.credential.into(),
                     sig_st_b.id.clone() => credential_b.credential.into()
             };
+            let pres_sch_id = random_string(16, rand::thread_rng());
 
             let (presentation_schema1, presentation_schema2): (
                 PresentationSchema,
                 PresentationSchema,
             ) = match equality_index {
                 None => (
-                    PresentationSchema::new(&[sig_st_a.clone().into(), sig_st_b.clone().into()]),
-                    PresentationSchema::new(&[sig_st_a        .into(), sig_st_b        .into()]),
+                    PresentationSchema::new_with_id(&[
+                        sig_st_a.clone().into(),
+                        sig_st_b.clone().into()
+                    ], &pres_sch_id),
+                    PresentationSchema::new_with_id(&[
+                        sig_st_a        .into(),
+                        sig_st_b        .into()
+                    ], &pres_sch_id),
                 ),
                 Some(i) => {
                     let eq_st = EqualityStatement {
@@ -227,12 +234,16 @@ mod reveal_and_equality_tests {
                         },
                     };
                     (
-                        PresentationSchema::new(&[
+                        PresentationSchema::new_with_id(&[
                             sig_st_a.clone().into(),
                             sig_st_b.clone().into(),
                             eq_st   .clone().into(),
-                        ]),
-                        PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()]),
+                        ], &pres_sch_id),
+                        PresentationSchema::new_with_id(&[
+                            sig_st_a.into(),
+                            sig_st_b.into(),
+                            eq_st   .into()
+                        ], &pres_sch_id),
                     )
                 }
             };

--- a/tests/equality-and-reveal.rs
+++ b/tests/equality-and-reveal.rs
@@ -210,8 +210,14 @@ mod reveal_and_equality_tests {
                     sig_st_b.id.clone() => credential_b.credential.into()
             };
 
-            let presentation_schema: PresentationSchema = match equality_index {
-                None => PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into()]),
+            let (presentation_schema1, presentation_schema2): (
+                PresentationSchema,
+                PresentationSchema,
+            ) = match equality_index {
+                None => (
+                    PresentationSchema::new(&[sig_st_a.clone().into(), sig_st_b.clone().into()]),
+                    PresentationSchema::new(&[sig_st_a        .into(), sig_st_b        .into()]),
+                ),
                 Some(i) => {
                     let eq_st = EqualityStatement {
                         id: random_string(16, rand::thread_rng()),
@@ -220,12 +226,20 @@ mod reveal_and_equality_tests {
                             sig_st_b.id.clone() => i
                         },
                     };
-                    PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()])
+                    (
+                        PresentationSchema::new(&[
+                            sig_st_a.clone().into(),
+                            sig_st_b.clone().into(),
+                            eq_st   .clone().into(),
+                        ]),
+                        PresentationSchema::new(&[sig_st_a.into(), sig_st_b.into(), eq_st.into()]),
+                    )
                 }
             };
 
-            let presentation = Presentation::create(&credentials, &presentation_schema, &nonce)?;
-            presentation.verify(&presentation_schema, &nonce)?;
+            // Prover and Verifier each use PresentationSchema generated independently
+            let presentation = Presentation::create(&credentials, &presentation_schema1, &nonce)?;
+            presentation.verify(&presentation_schema2, &nonce)?;
             Ok(presentation.disclosed_messages)
         }
     }


### PR DESCRIPTION
This PR adds a variant `new_with_id` for `PresentationSchema`, which accepts an ID as an argument, rather than generating one at random.

#### Motivation

The motivation is to enable Prover and Verifier to generate `PresentationSchema`s _independently_, rather than Prover having to accept one generated by Verifier, for example.  This also ensures that the two parties can generate _equal_ `PresentationSchema`s based on _equivalent_ requirements, possibly represented differently, which helps pave the way for more abstract representations of requirements.  (Note that the two parties would agree on the ID at the same level at which they would already agree on the `PresentationSchema`; this change enables them to use the same inputs---including ID---to independently generate the same `PresentationSchema`.)

#### Details

The first commit changes some tests so that the parties generate their `PresentationSchemas` independently using the existing `new`, which makes the tests fail.

The second commit introduces a variant `new_with_id`, which enables specifying an id, and changes the tests to use this variant, which makes the test pass again.

#### Potential alternative approach

An alternative would be to not add the `PresentationSchema` ID to the proof contributions, so that the proof doesn't care that different parties have different IDs.  This has the advantage that there would be no need to change the interface.

We think either approach would be acceptable.

If the proposed approach is accepted, would it also make sense to deprecate or even the existing `new` or even change to accept an ID, or is there some reason to retain the existing version?
