### PR TITLE
Require using Schnorr proofs from signature proof for predicates

### DIFF
--- a/src/knox/accumulator/vb20/proof.rs
+++ b/src/knox/accumulator/vb20/proof.rs
@@ -232,14 +232,14 @@ impl MembershipProofCommitting {
 /// A ZKP membership proof
 #[derive(Debug, Default, Copy, Clone, Deserialize, Serialize)]
 pub struct MembershipProof {
-    e_c: G1Projective,
-    t_sigma: G1Projective,
-    t_rho: G1Projective,
-    s_sigma: Scalar,
-    s_rho: Scalar,
-    s_delta_sigma: Scalar,
-    s_delta_rho: Scalar,
-    s_y: Scalar,
+    pub(crate) e_c: G1Projective,
+    pub(crate) t_sigma: G1Projective,
+    pub(crate) t_rho: G1Projective,
+    pub(crate) s_sigma: Scalar,
+    pub(crate) s_rho: Scalar,
+    pub(crate) s_delta_sigma: Scalar,
+    pub(crate) s_delta_rho: Scalar,
+    pub(crate) s_y: Scalar,
 }
 
 impl core::fmt::Display for MembershipProof {

--- a/src/knox/bbs/scheme.rs
+++ b/src/knox/bbs/scheme.rs
@@ -126,6 +126,6 @@ impl ShortGroupSignatureScheme for BbsScheme {
         transcript.challenge_bytes(b"signature proof of knowledge", &mut res);
         let v_challenge = Scalar::from_bytes_wide(&res);
 
-        proof.verify(revealed_msgs, public_key).is_ok() && challenge == v_challenge
+        proof.verify(public_key, revealed_msgs, challenge).is_ok() && challenge == v_challenge
     }
 }

--- a/src/knox/ps/pok_signature_proof.rs
+++ b/src/knox/ps/pok_signature_proof.rs
@@ -72,7 +72,12 @@ impl ProofOfSignatureKnowledge for PokSignatureProof {
     /// Validate the proof, only checks the signature proof
     /// the selective disclosure proof is checked by verifying
     /// self.challenge == computed_challenge
-    fn verify(&self, rvl_msgs: &[(usize, Scalar)], public_key: &PublicKey) -> CredxResult<()> {
+    fn verify(
+        &self,
+        public_key: &Self::PublicKey,
+        revealed_messages: &[(usize, Scalar)],
+        _challenge: Scalar,
+    ) -> CredxResult<()> {
         // check the signature proof
         if self
             .sigma_1
@@ -84,7 +89,7 @@ impl ProofOfSignatureKnowledge for PokSignatureProof {
             return Err(Error::General("Invalid proof - identity"));
         }
 
-        if public_key.y.len() < rvl_msgs.len() {
+        if public_key.y.len() < revealed_messages.len() {
             return Err(Error::General(
                 "Invalid key - revealed messages length is bigger than the public key",
             ));
@@ -96,7 +101,7 @@ impl ProofOfSignatureKnowledge for PokSignatureProof {
         let mut points = Vec::new();
         let mut scalars = Vec::new();
 
-        for (idx, msg) in rvl_msgs {
+        for (idx, msg) in revealed_messages {
             if *idx > public_key.y.len() {
                 return Err(Error::General("Invalid proof - revealed message index"));
             }

--- a/src/knox/ps/scheme.rs
+++ b/src/knox/ps/scheme.rs
@@ -135,6 +135,6 @@ impl ShortGroupSignatureScheme for PsScheme {
         transcript.challenge_bytes(b"signature proof of knowledge", &mut res);
         let v_challenge = Scalar::from_bytes_wide(&res);
 
-        proof.verify(revealed_msgs, public_key).is_ok() && challenge == v_challenge
+        proof.verify(public_key, revealed_msgs, challenge).is_ok() && challenge == v_challenge
     }
 }

--- a/src/knox/short_group_sig_core/proof_committed_builder.rs
+++ b/src/knox/short_group_sig_core/proof_committed_builder.rs
@@ -63,9 +63,13 @@ where
 
     /// Convert the committed values to bytes for the fiat-shamir challenge
     pub fn add_challenge_contribution(&self, label: &'static [u8], transcript: &mut Transcript) {
-        let mut scalars = self.scalars.clone();
-        let commitment = (self.sum_of_products)(self.points.as_ref(), scalars.as_mut());
+        let commitment = self.commitment();
         transcript.append_message(label, commitment.to_affine().to_bytes().as_ref());
+    }
+
+    pub fn commitment(&self) -> B {
+        let mut scalars = self.scalars.clone();
+        (self.sum_of_products)(self.points.as_ref(), scalars.as_mut())
     }
 
     /// Generate the Schnorr challenges given the specified secrets

--- a/src/knox/short_group_sig_core/short_group_traits.rs
+++ b/src/knox/short_group_sig_core/short_group_traits.rs
@@ -131,8 +131,9 @@ pub trait ProofOfSignatureKnowledge:
     /// Verify the signature proof of knowledge
     fn verify(
         &self,
-        revealed_messages: &[(usize, Scalar)],
         public_key: &Self::PublicKey,
+        revealed_messages: &[(usize, Scalar)],
+        challenge: Scalar,
     ) -> CredxResult<()>;
 
     /// Get the hidden message proofs

--- a/src/presentation/commitment.rs
+++ b/src/presentation/commitment.rs
@@ -12,19 +12,16 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct CommitmentBuilder<'a> {
     pub(crate) commitment: G1Projective,
     pub(crate) statement: &'a CommitmentStatement<G1Projective>,
-    pub(crate) message: Scalar,
     pub(crate) b: Scalar,
     pub(crate) r: Scalar,
 }
 
 impl<S: ShortGroupSignatureScheme> PresentationBuilder<S> for CommitmentBuilder<'_> {
     fn gen_proof(self, challenge: Scalar) -> PresentationProofs<S> {
-        let message_proof = self.b + challenge * self.message;
         let blinder_proof = self.r + challenge * self.b;
         CommitmentProof {
             id: self.statement.id.clone(),
             commitment: self.commitment,
-            message_proof,
             blinder_proof,
         }
         .into()
@@ -41,7 +38,6 @@ impl<'a> CommitmentBuilder<'a> {
         transcript: &mut Transcript,
     ) -> CredxResult<Self> {
         let r = Scalar::random(&mut rng);
-
         let commitment = statement.message_generator * message + statement.blinder_generator * b;
         let blind_commitment = statement.message_generator * b + statement.blinder_generator * r;
 
@@ -57,7 +53,6 @@ impl<'a> CommitmentBuilder<'a> {
         Ok(Self {
             commitment,
             statement,
-            message,
             b,
             r,
         })
@@ -71,8 +66,6 @@ pub struct CommitmentProof {
     pub id: String,
     /// The commitment
     pub commitment: G1Projective,
-    /// The schnorr message proof
-    pub message_proof: Scalar,
     /// The schnorr blinder proof
     pub blinder_proof: Scalar,
 }

--- a/src/presentation/verifiable_encryption.rs
+++ b/src/presentation/verifiable_encryption.rs
@@ -13,20 +13,18 @@ pub(crate) struct VerifiableEncryptionBuilder<'a> {
     c1: G1Projective,
     c2: G1Projective,
     statement: &'a VerifiableEncryptionStatement<G1Projective>,
-    message: Scalar,
     b: Scalar,
     r: Scalar,
 }
 
 impl<S: ShortGroupSignatureScheme> PresentationBuilder<S> for VerifiableEncryptionBuilder<'_> {
     fn gen_proof(self, challenge: Scalar) -> PresentationProofs<S> {
-        let message_proof = self.b + challenge * self.message;
+        // Message proof will be passed from signature proof
         let blinder_proof = self.r + challenge * self.b;
         VerifiableEncryptionProof {
             id: self.statement.id.clone(),
             c1: self.c1,
             c2: self.c2,
-            message_proof,
             blinder_proof,
         }
         .into()
@@ -60,7 +58,6 @@ impl<'a> VerifiableEncryptionBuilder<'a> {
             c1,
             c2,
             statement,
-            message,
             b,
             r,
         })
@@ -76,8 +73,6 @@ pub struct VerifiableEncryptionProof {
     pub c1: G1Projective,
     /// The C2 El-Gamal component
     pub c2: G1Projective,
-    /// The schnorr message proof
-    pub message_proof: Scalar,
     /// The schnorr blinder proof
     pub blinder_proof: Scalar,
 }

--- a/src/verifier/commitment.rs
+++ b/src/verifier/commitment.rs
@@ -9,6 +9,7 @@ use merlin::Transcript;
 pub struct CommitmentVerifier<'a, 'b> {
     pub statement: &'a CommitmentStatement<G1Projective>,
     pub proof: &'b CommitmentProof,
+    pub message_proof: Scalar,
 }
 
 impl ProofVerifier for CommitmentVerifier<'_, '_> {
@@ -18,7 +19,7 @@ impl ProofVerifier for CommitmentVerifier<'_, '_> {
         transcript: &mut Transcript,
     ) -> CredxResult<()> {
         let blind_commitment = self.proof.commitment * -challenge
-            + self.statement.message_generator * self.proof.message_proof
+            + self.statement.message_generator * self.message_proof
             + self.statement.blinder_generator * self.proof.blinder_proof;
 
         transcript.append_message(b"", self.statement.id.as_bytes());

--- a/src/verifier/membership.rs
+++ b/src/verifier/membership.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use crate::knox::accumulator::vb20::{Element, ProofParams};
 use crate::presentation::MembershipProof;
 use crate::statement::MembershipStatement;
@@ -10,6 +11,7 @@ pub struct MembershipVerifier<'a, 'b> {
     statement: &'a MembershipStatement,
     accumulator_proof: &'b MembershipProof,
     params: ProofParams,
+    message_proof: Scalar,
 }
 
 impl<'a, 'b> MembershipVerifier<'a, 'b> {
@@ -17,12 +19,14 @@ impl<'a, 'b> MembershipVerifier<'a, 'b> {
         statement: &'a MembershipStatement,
         accumulator_proof: &'b MembershipProof,
         nonce: &[u8],
+        message_proof: Scalar,
     ) -> Self {
         let params = ProofParams::new(statement.verification_key, Some(nonce));
         Self {
             statement,
             accumulator_proof,
             params,
+            message_proof,
         }
     }
 }
@@ -45,6 +49,9 @@ impl ProofVerifier for MembershipVerifier<'_, '_> {
     }
 
     fn verify(&self, _challenge: Scalar) -> CredxResult<()> {
+        if self.accumulator_proof.proof.s_y != self.message_proof {
+            return Err(Error::InvalidPresentationData);
+        }
         Ok(())
     }
 }

--- a/src/verifier/revocation.rs
+++ b/src/verifier/revocation.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use crate::knox::accumulator::vb20::{Element, ProofParams};
 use crate::presentation::RevocationProof;
 use crate::statement::RevocationStatement;
@@ -10,6 +11,7 @@ pub struct RevocationVerifier<'a, 'b> {
     statement: &'a RevocationStatement,
     accumulator_proof: &'b RevocationProof,
     params: ProofParams,
+    message_proof: Scalar,
 }
 
 impl<'a, 'b> RevocationVerifier<'a, 'b> {
@@ -17,12 +19,14 @@ impl<'a, 'b> RevocationVerifier<'a, 'b> {
         statement: &'a RevocationStatement,
         accumulator_proof: &'b RevocationProof,
         nonce: &[u8],
+        message_proof: Scalar,
     ) -> Self {
         let params = ProofParams::new(statement.verification_key, Some(nonce));
         Self {
             statement,
             accumulator_proof,
             params,
+            message_proof,
         }
     }
 }
@@ -45,6 +49,9 @@ impl ProofVerifier for RevocationVerifier<'_, '_> {
     }
 
     fn verify(&self, _challenge: Scalar) -> CredxResult<()> {
+        if self.accumulator_proof.proof.s_y != self.message_proof {
+            return Err(Error::InvalidPresentationData);
+        }
         Ok(())
     }
 }

--- a/src/verifier/signature.rs
+++ b/src/verifier/signature.rs
@@ -47,10 +47,11 @@ impl<S: ShortGroupSignatureScheme> ProofVerifier for SignatureVerifier<'_, '_, S
         Ok(())
     }
 
-    fn verify(&self, _challenge: Scalar) -> CredxResult<()> {
+    fn verify(&self, challenge: Scalar) -> CredxResult<()> {
         self.signature_proof.pok.verify(
-            &self.disclosed_messages,
             &self.statement.issuer.verifying_key,
+            &self.disclosed_messages,
+            challenge,
         )
     }
 }

--- a/src/verifier/verifiable_encryption.rs
+++ b/src/verifier/verifiable_encryption.rs
@@ -9,6 +9,7 @@ use merlin::Transcript;
 pub struct VerifiableEncryptionVerifier<'a, 'b> {
     pub statement: &'a VerifiableEncryptionStatement<G1Projective>,
     pub proof: &'b VerifiableEncryptionProof,
+    pub message_proof: Scalar,
 }
 
 impl ProofVerifier for VerifiableEncryptionVerifier<'_, '_> {
@@ -20,7 +21,7 @@ impl ProofVerifier for VerifiableEncryptionVerifier<'_, '_> {
         let challenge = -challenge;
         let r1 = self.proof.c1 * challenge + G1Projective::GENERATOR * self.proof.blinder_proof;
         let r2 = self.proof.c2 * challenge
-            + self.statement.message_generator * self.proof.message_proof
+            + self.statement.message_generator * self.message_proof
             + self.statement.encryption_key.0 * self.proof.blinder_proof;
 
         transcript.append_message(b"", self.statement.id.as_bytes());

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -3,6 +3,7 @@ use credx::claim::{ClaimType, HashedClaim, NumberClaim, RevocationClaim};
 use credx::credential::{ClaimSchema, CredentialSchema};
 use credx::issuer::Issuer;
 use credx::knox::bbs::BbsScheme;
+use credx::knox::ps::PsScheme;
 use credx::presentation::{Presentation, PresentationSchema};
 use credx::statement::{CommitmentStatement, RangeStatement, SignatureStatement};
 use credx::{random_string, CredxResult};
@@ -37,6 +38,11 @@ range_test_with!(in_range_max_implicit, isize::MAX, Some(0), None, false);
 // These tests are expected to fail (expected_to_fail argument is true)
 range_test_with!(out_of_range_below, 0, Some(1), Some(isize::MAX), true);
 range_test_with!(out_of_range_above, 1001, Some(0), Some(1000), true);
+
+#[test]
+fn test_out_of_range_above() {
+    assert!(test_range_proof_works(1000, Some(0), Some(1000), false).is_ok());
+}
 
 fn test_range_proof_works(
     val: isize,


### PR DESCRIPTION
Before, each predicate proof kept a copy of the hidden message proof. However, this wasn't checked against the signature proof. This PR removes the copy and just uses the signature proof hidden message proofs directly which guarantees to check if hidden messages were manipulated.