### PR TITLE
Add verifiable encryption / decryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 # NOTE: Please keep dependencies sorted alphabetically.
 [dependencies]
+aes-gcm = "0.10"
 base64 = "0.22"
 blsful = "3.0.0-pre8"
 bulletproofs = { version = "4.0.0", git = "https://github.com/cryptidtech/bulletproofs" }
@@ -19,6 +20,7 @@ maplit = "1"
 rand = "0.8"
 rand_chacha = "0.3"
 rand_core = "0.6"
+rayon = "1.10"
 regex = "1"
 rmp-serde = "1.3"
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -9,6 +9,7 @@ mod revocation;
 mod schema;
 mod signature;
 mod verifiable_encryption;
+mod verifiable_encryption_decryption;
 mod verify;
 
 pub use commitment::*;
@@ -21,6 +22,7 @@ pub use revocation::*;
 pub use schema::*;
 pub use signature::*;
 pub use verifiable_encryption::*;
+pub use verifiable_encryption_decryption::*;
 
 use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
 use crate::knox::short_group_sig_core::{HiddenMessage, ProofMessage};
@@ -49,6 +51,7 @@ pub(crate) enum PresentationBuilders<'a, S: ShortGroupSignatureScheme> {
     VerifiableEncryption(Box<VerifiableEncryptionBuilder<'a>>),
     Range(Box<RangeBuilder<'a>>),
     Membership(Box<MembershipProofBuilder<'a>>),
+    VerifiableEncryptionDecryption(Box<VerifiableEncryptionDecryptionBuilder<'a>>),
 }
 
 impl<S: ShortGroupSignatureScheme> PresentationBuilders<'_, S> {
@@ -62,6 +65,7 @@ impl<S: ShortGroupSignatureScheme> PresentationBuilders<'_, S> {
             Self::VerifiableEncryption(v) => v.gen_proof(challenge),
             Self::Range(r) => r.gen_proof(challenge),
             Self::Membership(m) => m.gen_proof(challenge),
+            Self::VerifiableEncryptionDecryption(v) => v.gen_proof(challenge),
         }
     }
 }
@@ -113,6 +117,14 @@ impl<'a, S: ShortGroupSignatureScheme> From<MembershipProofBuilder<'a>>
 {
     fn from(value: MembershipProofBuilder<'a>) -> Self {
         Self::Membership(Box::new(value))
+    }
+}
+
+impl<'a, S: ShortGroupSignatureScheme> From<VerifiableEncryptionDecryptionBuilder<'a>>
+    for PresentationBuilders<'a, S>
+{
+    fn from(value: VerifiableEncryptionDecryptionBuilder<'a>) -> Self {
+        Self::VerifiableEncryptionDecryption(Box::new(value))
     }
 }
 
@@ -205,13 +217,14 @@ impl<S: ShortGroupSignatureScheme> Presentation<S> {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     /// Map the claims to the respective types
     fn get_message_types<'a>(
         credentials: &IndexMap<String, PresentationCredential<S>>,
         signature_statements: &'a IndexMap<&String, &Statements<S>>,
         predicate_statements: &'a IndexMap<&String, &Statements<S>>,
         mut rng: impl RngCore + CryptoRng,
-    ) -> CredxResult<IndexMap<&'a String, Vec<ProofMessage<Scalar>>>> {
+    ) -> CredxResult<IndexMap<&'a String, Vec<(ClaimData, ProofMessage<Scalar>)>>> {
         let mut shared_proof_msg_indices: IndexMap<&String, Vec<bool>> = IndexMap::new();
 
         for (id, cred) in credentials {
@@ -222,7 +235,8 @@ impl<S: ShortGroupSignatureScheme> Presentation<S> {
 
         let mut same_proof_messages = Vec::new();
 
-        let mut proof_messages: IndexMap<&String, Vec<ProofMessage<Scalar>>> = IndexMap::new();
+        let mut proof_messages: IndexMap<&String, Vec<(ClaimData, ProofMessage<Scalar>)>> =
+            IndexMap::new();
 
         // If a claim is used in a statement, it is a shared message between the signature
         // and the statement. Equality statements are shared across signatures
@@ -270,16 +284,20 @@ impl<S: ShortGroupSignatureScheme> Presentation<S> {
                 if let Statements::Signature(ss) = sig {
                     let claim_label = ss.issuer.schema.claim_indices.get_index(index).unwrap();
                     if ss.disclosed.contains(claim_label) {
-                        proof_claims.push(ProofMessage::Revealed(claim_value));
+                        proof_claims.push((claim.clone(), ProofMessage::Revealed(claim_value)));
                     } else if shared_proof_msg_indices[id][index] {
                         let blinder = Scalar::random(&mut rng);
-                        proof_claims.push(ProofMessage::Hidden(HiddenMessage::ExternalBlinding(
-                            claim_value,
-                            blinder,
-                        )));
+                        proof_claims.push((
+                            claim.clone(),
+                            ProofMessage::Hidden(HiddenMessage::ExternalBlinding(
+                                claim_value,
+                                blinder,
+                            )),
+                        ));
                     } else {
-                        proof_claims.push(ProofMessage::Hidden(
-                            HiddenMessage::ProofSpecificBlinding(claim_value),
+                        proof_claims.push((
+                            claim.clone(),
+                            ProofMessage::Hidden(HiddenMessage::ProofSpecificBlinding(claim_value)),
                         ));
                     }
                 }
@@ -297,14 +315,15 @@ impl<S: ShortGroupSignatureScheme> Presentation<S> {
                 let map2 = proof_messages.get_mut(id2).unwrap();
                 // NOTE: other unexpected combinations could be checked too,
                 // e.g., one ProofSpecificBlinding, one ExternalBlinding
-                if matches!(map1[ix1], ProofMessage::Revealed(_))
-                    || matches!(map2[ix2], ProofMessage::Revealed(_))
+                if matches!(map1[ix1].1, ProofMessage::Revealed(_))
+                    || matches!(map2[ix2].1, ProofMessage::Revealed(_))
                 {
                     return Err(Error::InvalidClaimData(
                         "revealed claim cannot be used with equality proof",
                     ));
                 }
-                map2[ix2] = map1[ix1];
+                map2[ix2].0 = map1[ix1].0.clone();
+                map2[ix2].1 = map1[ix1].1;
             }
         }
 

--- a/src/presentation/proof.rs
+++ b/src/presentation/proof.rs
@@ -1,5 +1,6 @@
 use super::SignatureProof;
 use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
+use crate::presentation::verifiable_encryption_decryption::VerifiableEncryptionDecryptionProof;
 use crate::presentation::{
     CommitmentProof, EqualityProof, MembershipProof, RangeProof, RevocationProof,
     VerifiableEncryptionProof,
@@ -27,6 +28,8 @@ pub enum PresentationProofs<S: ShortGroupSignatureScheme> {
     Range(Box<RangeProof>),
     /// Membership Proofs
     Membership(Box<MembershipProof>),
+    /// Verifiable Encryption Decryption Proofs
+    VerifiableEncryptionDecryption(Box<VerifiableEncryptionDecryptionProof>),
 }
 
 impl<S: ShortGroupSignatureScheme> From<SignatureProof<S>> for PresentationProofs<S> {
@@ -71,6 +74,14 @@ impl<S: ShortGroupSignatureScheme> From<MembershipProof> for PresentationProofs<
     }
 }
 
+impl<S: ShortGroupSignatureScheme> From<VerifiableEncryptionDecryptionProof>
+    for PresentationProofs<S>
+{
+    fn from(value: VerifiableEncryptionDecryptionProof) -> Self {
+        Self::VerifiableEncryptionDecryption(Box::new(value))
+    }
+}
+
 impl<S: ShortGroupSignatureScheme> PresentationProofs<S> {
     /// Get the underlying statement identifier
     pub fn id(&self) -> &String {
@@ -82,6 +93,7 @@ impl<S: ShortGroupSignatureScheme> PresentationProofs<S> {
             Self::VerifiableEncryption(v) => &v.id,
             Self::Range(r) => &r.id,
             Self::Membership(m) => &m.id,
+            Self::VerifiableEncryptionDecryption(v) => &v.id,
         }
     }
 }

--- a/src/presentation/verifiable_encryption.rs
+++ b/src/presentation/verifiable_encryption.rs
@@ -3,18 +3,18 @@ use crate::presentation::{PresentationBuilder, PresentationProofs};
 use crate::statement::VerifiableEncryptionStatement;
 use crate::CredxResult;
 use blsful::inner_types::{G1Projective, Scalar};
-use elliptic_curve::{ff::Field, group::Curve};
+use elliptic_curve::ff::Field;
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 /// Verifiable encryption builder
 pub(crate) struct VerifiableEncryptionBuilder<'a> {
-    c1: G1Projective,
-    c2: G1Projective,
-    statement: &'a VerifiableEncryptionStatement<G1Projective>,
-    b: Scalar,
-    r: Scalar,
+    pub(crate) c1: G1Projective,
+    pub(crate) c2: G1Projective,
+    pub(crate) statement: &'a VerifiableEncryptionStatement<G1Projective>,
+    pub(crate) b: Scalar,
+    pub(crate) r: Scalar,
 }
 
 impl<S: ShortGroupSignatureScheme> PresentationBuilder<S> for VerifiableEncryptionBuilder<'_> {
@@ -48,10 +48,10 @@ impl<'a> VerifiableEncryptionBuilder<'a> {
         let r2 = statement.message_generator * b + statement.encryption_key.0 * r;
 
         transcript.append_message(b"", statement.id.as_bytes());
-        transcript.append_message(b"c1", c1.to_affine().to_compressed().as_slice());
-        transcript.append_message(b"c2", c2.to_affine().to_compressed().as_slice());
-        transcript.append_message(b"r1", r1.to_affine().to_compressed().as_slice());
-        transcript.append_message(b"r2", r2.to_affine().to_compressed().as_slice());
+        transcript.append_message(b"c1", c1.to_compressed().as_slice());
+        transcript.append_message(b"c2", c2.to_compressed().as_slice());
+        transcript.append_message(b"r1", r1.to_compressed().as_slice());
+        transcript.append_message(b"r2", r2.to_compressed().as_slice());
 
         Ok(Self {
             c1,

--- a/src/presentation/verifiable_encryption_decryption.rs
+++ b/src/presentation/verifiable_encryption_decryption.rs
@@ -1,0 +1,291 @@
+use crate::claim::ClaimData;
+use crate::error::Error;
+use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
+use crate::prelude::{PresentationBuilder, PresentationProofs};
+use crate::statement::VerifiableEncryptionDecryptionStatement;
+use crate::CredxResult;
+use aes_gcm::aead::Aead;
+use aes_gcm::{AeadCore, Aes128Gcm, KeyInit, Nonce};
+use blsful::inner_types::{G1Projective, Scalar};
+use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+use elliptic_curve::bigint::U384;
+use elliptic_curve::scalar::FromUintUnchecked;
+use elliptic_curve::Field;
+use elliptic_curve_tools::{group_array, prime_field};
+use merlin::Transcript;
+use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+pub(crate) struct VerifiableEncryptionDecryptionBuilder<'a> {
+    c1: G1Projective,
+    c2: G1Projective,
+    statement: &'a VerifiableEncryptionDecryptionStatement<G1Projective>,
+    b: Scalar,
+    r: Scalar,
+    message_bytes: [u8; 32],
+    byte_blinders: [Scalar; 32],
+    blinder_blinders: [Scalar; 32],
+    byte_ciphertext: Ciphertext,
+    arbitrary_data_ciphertext: Vec<u8>,
+}
+
+impl<S: ShortGroupSignatureScheme> PresentationBuilder<S>
+    for VerifiableEncryptionDecryptionBuilder<'_>
+{
+    fn gen_proof(self, challenge: Scalar) -> PresentationProofs<S> {
+        let bp_gens = BulletproofGens::new(8, self.message_bytes.len());
+        let pedersen_gen = PedersenGens {
+            B: self.statement.message_generator,
+            B_blinding: self.statement.encryption_key.0,
+        };
+
+        let mut transcript = Transcript::new(b"PresentationEncryptionDecryption byte range proof");
+        transcript.append_message(b"challenge", &challenge.to_be_bytes());
+        let key_segments = self
+            .message_bytes
+            .iter()
+            .map(|b| *b as u64)
+            .collect::<Vec<_>>();
+        let (range_proof, _) = RangeProof::prove_multiple(
+            &bp_gens,
+            &pedersen_gen,
+            &mut transcript,
+            &key_segments,
+            &self.byte_blinders,
+            8,
+        )
+        .expect("range proof to work");
+        let blinder_proof = self.r + challenge * self.b;
+        let mut byte_proofs = [ByteProof::default(); 32];
+        for ((byte_proof, byte_blinder), (message_byte, blinder_blinder)) in byte_proofs
+            .iter_mut()
+            .zip(self.byte_blinders.iter())
+            .zip(self.message_bytes.iter().zip(self.blinder_blinders.iter()))
+        {
+            *byte_proof = ByteProof {
+                message: byte_blinder + challenge * Scalar::from(*message_byte),
+                blinder: blinder_blinder + challenge * byte_blinder,
+            };
+        }
+        VerifiableEncryptionDecryptionProof {
+            id: self.statement.id.clone(),
+            message_generator: self.statement.message_generator,
+            byte_proofs,
+            range_proof,
+            c1: self.c1,
+            c2: self.c2,
+            blinder_proof,
+            byte_ciphertext: self.byte_ciphertext,
+            ciphertext: self.arbitrary_data_ciphertext,
+        }
+        .into()
+    }
+}
+
+impl<'a> VerifiableEncryptionDecryptionBuilder<'a> {
+    pub fn commit(
+        statement: &'a VerifiableEncryptionDecryptionStatement<G1Projective>,
+        message: &ClaimData,
+        msg: Scalar,
+        b: Scalar,
+        mut rng: impl RngCore + CryptoRng,
+        transcript: &mut Transcript,
+    ) -> CredxResult<Self> {
+        let r = Scalar::random(&mut rng);
+
+        let c1 = G1Projective::GENERATOR * b;
+        let c2 = statement.message_generator * msg + statement.encryption_key.0 * b;
+
+        let r1 = G1Projective::GENERATOR * r;
+        let r2 = statement.message_generator * b + statement.encryption_key.0 * r;
+
+        let message_bytes = msg.to_be_bytes();
+        // The idea is for the byte blinders to sum to `b`
+        // Need to generate `message_bytes.len() - 1` random scalars
+        // and the last one will be `b` - sum(all others)
+        let mut byte_ciphertext = Ciphertext::default();
+        let mut byte_blinders = [Scalar::ZERO; 32];
+        let mut blinder_blinders = [Scalar::ZERO; 32];
+        let mut sum = b;
+
+        let eight = U384::from_u8(8);
+        let mut shift = U384::ONE << 248;
+        for i in 0..message_bytes.len() - 1 {
+            let blinder = Scalar::random(&mut rng);
+            let divisor = Scalar::from_uint_unchecked(shift)
+                .invert()
+                .expect("divisor to not be zero");
+            let shifted_blinder = blinder * divisor;
+
+            sum -= shifted_blinder;
+            shift = shift.wrapping_sub(&eight);
+
+            blinder_blinders[i] = Scalar::random(&mut rng);
+            byte_blinders[i] = shifted_blinder;
+
+            byte_ciphertext.c1[i] = G1Projective::GENERATOR * shifted_blinder;
+            byte_ciphertext.c2[i] = statement.message_generator * Scalar::from(message_bytes[i])
+                + statement.encryption_key.0 * shifted_blinder;
+        }
+        byte_blinders[31] = sum;
+
+        transcript.append_message(b"", statement.id.as_bytes());
+        transcript.append_message(b"c1", c1.to_compressed().as_slice());
+        transcript.append_message(b"c2", c2.to_compressed().as_slice());
+        transcript.append_message(b"r1", r1.to_compressed().as_slice());
+        transcript.append_message(b"r2", r2.to_compressed().as_slice());
+
+        for i in 0..message_bytes.len() {
+            transcript.append_u64(
+                b"verifiable_encryption_decryption_message_byte_index",
+                i as u64,
+            );
+            transcript.append_message(
+                b"byte_proof_c1",
+                byte_ciphertext.c1[i].to_compressed().as_slice(),
+            );
+            transcript.append_message(
+                b"byte_proof_c2",
+                byte_ciphertext.c2[i].to_compressed().as_slice(),
+            );
+            let inner_r1 = G1Projective::GENERATOR * blinder_blinders[i];
+            let inner_r2 = statement.message_generator * byte_blinders[i]
+                + statement.encryption_key.0 * blinder_blinders[i];
+            transcript.append_message(b"byte_proof_r1", inner_r1.to_compressed().as_slice());
+            transcript.append_message(b"byte_proof_r2", inner_r2.to_compressed().as_slice());
+        }
+
+        let arbitrary_data = message.to_text();
+        let mut aes_transcript =
+            Transcript::new(b"PresentationEncryptionDecryption arbitrary data derive aes key");
+        let input = statement.encryption_key.0 * b;
+        aes_transcript.append_message(b"key ikm", input.to_compressed().as_slice());
+        let mut okm = [0u8; 32];
+        aes_transcript.challenge_bytes(b"aes key", &mut okm);
+        let nonce = Aes128Gcm::generate_nonce(&mut rng);
+        let key = aes_gcm::Key::<Aes128Gcm>::from_slice(&okm[..16]);
+        let aad = okm[16..]
+            .iter()
+            .copied()
+            .chain(c1.to_compressed())
+            .chain(c2.to_compressed())
+            .collect::<Vec<_>>();
+        let cipher = Aes128Gcm::new(key);
+        let payload = aes_gcm::aead::Payload {
+            msg: arbitrary_data.as_bytes(),
+            aad: &aad,
+        };
+        let mut ciphertext = nonce.to_vec();
+        ciphertext.append(
+            &mut cipher
+                .encrypt(&nonce, payload)
+                .expect("encryption message to be encrypted"),
+        );
+        transcript.append_message(b"arbitrary_data_ciphertext", &ciphertext);
+        let arbitrary_data_ciphertext = ciphertext;
+
+        Ok(Self {
+            c1,
+            c2,
+            statement,
+            b,
+            r,
+            message_bytes,
+            byte_blinders,
+            blinder_blinders,
+            byte_ciphertext,
+            arbitrary_data_ciphertext,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifiableEncryptionDecryptionProof {
+    /// The statement identifier
+    pub id: String,
+    /// The original message generator
+    pub message_generator: G1Projective,
+    /// The message decomposed into schnorr byte proofs
+    pub byte_proofs: [ByteProof; 32],
+    /// Byte range proofs
+    pub range_proof: RangeProof,
+    /// DLog proof
+    pub c1: G1Projective,
+    /// DLog proof
+    pub c2: G1Projective,
+    /// The schnorr blinder proof
+    pub blinder_proof: Scalar,
+    /// The byte ciphertext
+    pub byte_ciphertext: Ciphertext,
+    /// The encrypted arbitrary data if the statement included it
+    pub ciphertext: Vec<u8>,
+}
+
+impl VerifiableEncryptionDecryptionProof {
+    pub fn decrypt_and_verify(&self, decryption_key: &Scalar) -> CredxResult<ClaimData> {
+        // 12 for the nonce
+        // 16 for the tag
+        // 16 for at least one block
+        if self.ciphertext.len() < 12 + 16 + 16 {
+            return Err(Error::General("arbitrary data ciphertext is too short"));
+        }
+
+        let input = self.c1 * decryption_key;
+        let expected_commitment = self.c2 - input;
+        let nonce = Nonce::from_slice(&self.ciphertext[..12]);
+
+        let mut aes_transcript =
+            Transcript::new(b"PresentationEncryptionDecryption arbitrary data derive aes key");
+        aes_transcript.append_message(b"key ikm", input.to_compressed().as_slice());
+        let mut okm = [0u8; 32];
+        aes_transcript.challenge_bytes(b"aes key", &mut okm);
+
+        let key = aes_gcm::Key::<Aes128Gcm>::from_slice(&okm[..16]);
+        let aad = okm[16..]
+            .iter()
+            .copied()
+            .chain(self.c1.to_compressed())
+            .chain(self.c2.to_compressed())
+            .collect::<Vec<_>>();
+        let cipher = Aes128Gcm::new(key);
+        let payload = aes_gcm::aead::Payload {
+            msg: &self.ciphertext[12..],
+            aad: &aad,
+        };
+        let plaintext = cipher
+            .decrypt(nonce, payload)
+            .map_err(|_| Error::General("unable to decrypt arbitrary data: aes-128-gcm"))?;
+        let plaintext = String::from_utf8(plaintext)
+            .map_err(|_| Error::General("unable to convert decrypted data to utf-8"))?;
+        let claim = ClaimData::from_text(&plaintext)?;
+        let computed_commitment = self.message_generator * claim.to_scalar();
+        if computed_commitment != expected_commitment {
+            return Err(Error::General(
+                "Invalid decrypted data. Computed commitment does not match expected commitment.",
+            ));
+        }
+        Ok(claim)
+    }
+}
+
+/// A schnorr proof of knowledge of a byte
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
+pub struct ByteProof {
+    /// The message schnorr proof
+    #[serde(with = "prime_field")]
+    pub message: Scalar,
+    /// The blinder schnorr proof
+    #[serde(with = "prime_field")]
+    pub blinder: Scalar,
+}
+
+/// A ciphertext that encodes a scalar
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Ciphertext {
+    /// The El-Gamal C1 values
+    #[serde(with = "group_array")]
+    pub c1: [G1Projective; 32],
+    /// The El-Gamal C2 values
+    #[serde(with = "group_array")]
+    pub c2: [G1Projective; 32],
+}

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -5,6 +5,7 @@ mod range;
 mod revocation;
 mod signature;
 mod verifiable_encryption;
+mod verifiable_encryption_decryption;
 
 pub use commitment::*;
 pub use equality::*;
@@ -12,13 +13,14 @@ pub use membership::*;
 pub use range::*;
 pub use revocation::*;
 pub use signature::*;
-use std::fmt::Formatter;
 pub use verifiable_encryption::*;
+pub use verifiable_encryption_decryption::*;
 
 use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
 use blsful::inner_types::G1Projective;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::Formatter;
 
 /// Statement methods
 pub trait Statement {
@@ -53,6 +55,7 @@ pub enum Statements<S: ShortGroupSignatureScheme> {
     Range(Box<RangeStatement>),
     /// Membership statements
     Membership(Box<MembershipStatement>),
+    VerifiableEncryptionDecryption(Box<VerifiableEncryptionDecryptionStatement<G1Projective>>),
 }
 
 impl<S: ShortGroupSignatureScheme> From<SignatureStatement<S>> for Statements<S> {
@@ -99,6 +102,14 @@ impl<S: ShortGroupSignatureScheme> From<MembershipStatement> for Statements<S> {
     }
 }
 
+impl<S: ShortGroupSignatureScheme> From<VerifiableEncryptionDecryptionStatement<G1Projective>>
+    for Statements<S>
+{
+    fn from(m: VerifiableEncryptionDecryptionStatement<G1Projective>) -> Self {
+        Self::VerifiableEncryptionDecryption(Box::new(m))
+    }
+}
+
 impl<S: ShortGroupSignatureScheme> Statements<S> {
     /// Return the statement id
     pub fn id(&self) -> String {
@@ -110,6 +121,7 @@ impl<S: ShortGroupSignatureScheme> Statements<S> {
             Self::VerifiableEncryption(v) => v.id(),
             Self::Range(r) => r.id(),
             Self::Membership(m) => m.id(),
+            Self::VerifiableEncryptionDecryption(v) => v.id(),
         }
     }
 
@@ -123,6 +135,7 @@ impl<S: ShortGroupSignatureScheme> Statements<S> {
             Self::VerifiableEncryption(v) => v.reference_ids(),
             Self::Range(r) => r.reference_ids(),
             Self::Membership(m) => m.reference_ids(),
+            Self::VerifiableEncryptionDecryption(v) => v.reference_ids(),
         }
     }
 
@@ -136,6 +149,7 @@ impl<S: ShortGroupSignatureScheme> Statements<S> {
             Self::VerifiableEncryption(v) => v.add_challenge_contribution(transcript),
             Self::Range(r) => r.add_challenge_contribution(transcript),
             Self::Membership(m) => m.add_challenge_contribution(transcript),
+            Self::VerifiableEncryptionDecryption(v) => v.add_challenge_contribution(transcript),
         }
     }
 
@@ -149,6 +163,7 @@ impl<S: ShortGroupSignatureScheme> Statements<S> {
             Self::VerifiableEncryption(v) => v.get_claim_index(reference_id),
             Self::Range(r) => r.get_claim_index(reference_id),
             Self::Membership(m) => m.get_claim_index(reference_id),
+            Self::VerifiableEncryptionDecryption(v) => v.get_claim_index(reference_id),
         }
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -14,6 +14,7 @@ pub use range::*;
 pub use revocation::*;
 pub use signature::*;
 pub use verifiable_encryption::*;
+pub use verifiable_encryption_decryption::*;
 
 use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
 use crate::CredxResult;
@@ -40,6 +41,7 @@ pub(crate) enum ProofVerifiers<'a, 'b, 'c, S: ShortGroupSignatureScheme> {
     VerifiableEncryption(Box<VerifiableEncryptionVerifier<'a, 'b>>),
     Range(Box<RangeProofVerifier<'a, 'b, 'c>>),
     Membership(Box<MembershipVerifier<'a, 'b>>),
+    VerifiableEncryptionDecryption(Box<VerifiableEncryptionDecryptionVerifier<'a, 'b>>),
 }
 
 impl<'a, 'b, S: ShortGroupSignatureScheme> From<SignatureVerifier<'a, 'b, S>>
@@ -98,6 +100,14 @@ impl<'a, 'b, S: ShortGroupSignatureScheme> From<MembershipVerifier<'a, 'b>>
     }
 }
 
+impl<'a, 'b, S: ShortGroupSignatureScheme> From<VerifiableEncryptionDecryptionVerifier<'a, 'b>>
+    for ProofVerifiers<'a, 'b, '_, S>
+{
+    fn from(a: VerifiableEncryptionDecryptionVerifier<'a, 'b>) -> Self {
+        Self::VerifiableEncryptionDecryption(Box::new(a))
+    }
+}
+
 impl<S: ShortGroupSignatureScheme> ProofVerifiers<'_, '_, '_, S> {
     /// Verify any additional proof material
     pub fn verify(&self, challenge: Scalar) -> CredxResult<()> {
@@ -109,6 +119,7 @@ impl<S: ShortGroupSignatureScheme> ProofVerifiers<'_, '_, '_, S> {
             Self::VerifiableEncryption(v) => v.verify(challenge),
             Self::Range(r) => r.verify(challenge),
             Self::Membership(m) => m.verify(challenge),
+            Self::VerifiableEncryptionDecryption(v) => v.verify(challenge),
         }
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -5,6 +5,7 @@ mod range;
 mod revocation;
 mod signature;
 mod verifiable_encryption;
+mod verifiable_encryption_decryption;
 
 pub use commitment::*;
 pub use equality::*;

--- a/src/verifier/verifiable_encryption_decryption.rs
+++ b/src/verifier/verifiable_encryption_decryption.rs
@@ -1,0 +1,101 @@
+use crate::error::Error;
+use crate::prelude::VerifiableEncryptionDecryptionStatement;
+use crate::presentation::VerifiableEncryptionDecryptionProof;
+use crate::verifier::ProofVerifier;
+use crate::CredxResult;
+use blsful::inner_types::{Curve, G1Projective, Scalar};
+use bulletproofs::{BulletproofGens, PedersenGens};
+use elliptic_curve::bigint::U384;
+use elliptic_curve::scalar::FromUintUnchecked;
+use merlin::Transcript;
+
+pub struct VerifiableEncryptionDecryptionVerifier<'a, 'b> {
+    pub statement: &'a VerifiableEncryptionDecryptionStatement<G1Projective>,
+    pub proof: &'b VerifiableEncryptionDecryptionProof,
+    pub message_proof: Scalar,
+}
+
+impl ProofVerifier for VerifiableEncryptionDecryptionVerifier<'_, '_> {
+    fn add_challenge_contribution(
+        &self,
+        challenge: Scalar,
+        transcript: &mut Transcript,
+    ) -> CredxResult<()> {
+        let challenge = -challenge;
+        let r1 = self.proof.c1 * challenge + G1Projective::GENERATOR * self.proof.blinder_proof;
+        let r2 = self.proof.c2 * challenge
+            + self.statement.message_generator * self.message_proof
+            + self.statement.encryption_key.0 * self.proof.blinder_proof;
+
+        transcript.append_message(b"", self.statement.id.as_bytes());
+        transcript.append_message(b"c1", self.proof.c1.to_affine().to_compressed().as_slice());
+        transcript.append_message(b"c2", self.proof.c2.to_affine().to_compressed().as_slice());
+        transcript.append_message(b"r1", r1.to_affine().to_compressed().as_slice());
+        transcript.append_message(b"r2", r2.to_affine().to_compressed().as_slice());
+
+        for i in 0..self.proof.byte_proofs.len() {
+            transcript.append_u64(
+                b"verifiable_encryption_decryption_message_byte_index",
+                i as u64,
+            );
+
+            transcript.append_message(
+                b"byte_proof_c1",
+                self.proof.byte_ciphertext.c1[i].to_compressed().as_slice(),
+            );
+            transcript.append_message(
+                b"byte_proof_c2",
+                self.proof.byte_ciphertext.c2[i].to_compressed().as_slice(),
+            );
+            let inner_r1 = self.proof.byte_ciphertext.c1[i] * challenge
+                + G1Projective::GENERATOR * self.proof.byte_proofs[i].blinder;
+            let inner_r2 = self.proof.byte_ciphertext.c2[i] * challenge
+                + self.statement.encryption_key.0 * self.proof.byte_proofs[i].blinder
+                + self.statement.message_generator * self.proof.byte_proofs[i].message;
+            transcript.append_message(b"byte_proof_r1", inner_r1.to_compressed().as_slice());
+            transcript.append_message(b"byte_proof_r2", inner_r2.to_compressed().as_slice());
+        }
+        transcript.append_message(b"arbitrary_data_ciphertext", &self.proof.ciphertext);
+
+        Ok(())
+    }
+
+    fn verify(&self, challenge: Scalar) -> CredxResult<()> {
+        let bp_gens = BulletproofGens::new(8, self.proof.byte_proofs.len());
+        let pedersen_gen = PedersenGens {
+            B: self.statement.message_generator,
+            B_blinding: self.statement.encryption_key.0,
+        };
+
+        let mut transcript = Transcript::new(b"PresentationEncryptionDecryption byte range proof");
+        transcript.append_message(b"challenge", &challenge.to_be_bytes());
+        // Prove each byte is in the range [0, 255]
+        self.proof
+            .range_proof
+            .verify_multiple(
+                &bp_gens,
+                &pedersen_gen,
+                &mut transcript,
+                &self.proof.byte_ciphertext.c2,
+                8,
+            )
+            .map_err(|_| Error::General("Range proof verification failed"))?;
+
+        let eight = U384::from_u8(8);
+        let mut shift = U384::ZERO;
+        let mut sum = G1Projective::IDENTITY;
+
+        for c2 in &self.proof.byte_ciphertext.c2 {
+            let multiplier = Scalar::from_uint_unchecked(shift);
+            sum += c2 * multiplier;
+            shift = shift.wrapping_add(&eight);
+        }
+
+        if sum != self.proof.c2 {
+            return Err(Error::General(
+                "Sum of byte ciphertexts does not match the ciphertext",
+            ));
+        }
+        Ok(())
+    }
+}

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -3,6 +3,7 @@ use credx::claim::{ClaimType, HashedClaim, NumberClaim, RevocationClaim};
 use credx::credential::{ClaimSchema, CredentialSchema};
 use credx::issuer::Issuer;
 use credx::knox::bbs::BbsScheme;
+use credx::knox::ps::PsScheme;
 use credx::presentation::{Presentation, PresentationSchema};
 use credx::statement::{CommitmentStatement, RangeStatement, SignatureStatement};
 use credx::{random_string, CredxResult};


### PR DESCRIPTION
This adds a verifiable encryption / decryption predicate.

The difference between this predicate and `VerifiableEncryption` is mainly this:

- `VerifiableEncryption` is useful when a list of possible values is encrypted and trial decryption can be performed quickly. This only proves encryption of a scalar value of the claim.
- `VerifiableEncryptionDecryption` is useful for encrypting arbitrary data and then decrypting it later. Here the scalar value of the claim is likewise proven but also provides a means to decrypt the arbitrary data verifiably. If the resulting decrypted plaintext is not correct it returns an error. 

The verifier obviously can't decrypt the data in either case as before but at least arbitrary claim data is now supported.