### PR TITLE
Add allow decryption of scalar

### DIFF
--- a/src/claim/number.rs
+++ b/src/claim/number.rs
@@ -49,7 +49,7 @@ macro_rules! impl_from {
 impl From<Scalar> for NumberClaim {
     fn from(value: Scalar) -> Self {
         let limb = <[u8; 8]>::try_from(&value.to_le_bytes()[..8])
-            .expect("Scalar is 32 bytes, so 4 bytes should exist");
+            .expect("Scalar is 32 bytes, so 8 bytes should exist");
         Self::from(zero_center(u64::from_le_bytes(limb) as isize))
     }
 }

--- a/src/claim/number.rs
+++ b/src/claim/number.rs
@@ -1,4 +1,5 @@
 use super::{Claim, ClaimType};
+use crate::utils::zero_center;
 use crate::{error::Error, utils::get_num_scalar};
 use blsful::inner_types::Scalar;
 use chrono::Datelike;
@@ -43,6 +44,14 @@ macro_rules! impl_from {
             }
         )*
     };
+}
+
+impl From<Scalar> for NumberClaim {
+    fn from(value: Scalar) -> Self {
+        let limb = <[u8; 8]>::try_from(&value.to_le_bytes()[..8])
+            .expect("Scalar is 32 bytes, so 4 bytes should exist");
+        Self::from(zero_center(u64::from_le_bytes(limb) as isize))
+    }
 }
 
 impl From<isize> for NumberClaim {

--- a/src/claim/scalar.rs
+++ b/src/claim/scalar.rs
@@ -41,14 +41,14 @@ impl From<Scalar> for ScalarClaim {
 
 impl ScalarClaim {
     pub fn encode_str(value: &str) -> CredxResult<Self> {
-        if value.len() > 30 {
+        if value.len() > 31 {
             return Err(Error::InvalidClaimData(
-                "scalar claim can only store 30 bytes or less and cannot be empty",
+                "scalar claim can only store 31 bytes or less",
             ));
         }
         let mut bytes = [0u8; 32];
         if !value.is_empty() {
-            bytes[1] = value.len() as u8;
+            bytes[0] = value.len() as u8;
             bytes[32 - value.len()..].copy_from_slice(value.as_bytes());
         }
         let s = Option::<Scalar>::from(Scalar::from_be_bytes(&bytes))
@@ -58,20 +58,20 @@ impl ScalarClaim {
 
     pub fn decode_to_str(&self) -> CredxResult<String> {
         let data = self.value.to_be_bytes();
-        let len = data[1] as usize;
+        let len = data[0] as usize;
         String::from_utf8(data[32 - len..].to_vec())
             .map_err(|_| Error::InvalidClaimData("scalar claim is not valid UTF-8"))
     }
 
     pub fn encode_bytes(value: &[u8]) -> CredxResult<Self> {
-        if value.len() > 30 {
+        if value.len() > 31 {
             return Err(Error::InvalidClaimData(
-                "scalar claim can only store 30 bytes or less",
+                "scalar claim can only store 31 bytes or less",
             ));
         }
         let mut bytes = [0u8; 32];
         if !value.is_empty() {
-            bytes[1] = value.len() as u8;
+            bytes[0] = value.len() as u8;
             bytes[32 - value.len()..].copy_from_slice(value);
         }
         let s = Option::<Scalar>::from(Scalar::from_be_bytes(&bytes))

--- a/src/claim/scalar.rs
+++ b/src/claim/scalar.rs
@@ -1,4 +1,6 @@
 use super::{Claim, ClaimType};
+use crate::error::Error;
+use crate::CredxResult;
 use blsful::inner_types::Scalar;
 use core::{
     fmt::{self, Display, Formatter},
@@ -34,6 +36,53 @@ impl Display for ScalarClaim {
 impl From<Scalar> for ScalarClaim {
     fn from(value: Scalar) -> Self {
         Self { value }
+    }
+}
+
+impl ScalarClaim {
+    pub fn encode_str(value: &str) -> CredxResult<Self> {
+        if value.len() > 30 {
+            return Err(Error::InvalidClaimData(
+                "scalar claim can only store 30 bytes or less and cannot be empty",
+            ));
+        }
+        let mut bytes = [0u8; 32];
+        if !value.is_empty() {
+            bytes[1] = value.len() as u8;
+            bytes[32 - value.len()..].copy_from_slice(value.as_bytes());
+        }
+        let s = Option::<Scalar>::from(Scalar::from_be_bytes(&bytes))
+            .ok_or(Error::InvalidClaimData("scalar claim is not valid UTF-8"))?;
+        Ok(Self::from(s))
+    }
+
+    pub fn decode_to_str(&self) -> CredxResult<String> {
+        let data = self.value.to_be_bytes();
+        let len = data[1] as usize;
+        String::from_utf8(data[32 - len..].to_vec())
+            .map_err(|_| Error::InvalidClaimData("scalar claim is not valid UTF-8"))
+    }
+
+    pub fn encode_bytes(value: &[u8]) -> CredxResult<Self> {
+        if value.len() > 30 {
+            return Err(Error::InvalidClaimData(
+                "scalar claim can only store 30 bytes or less",
+            ));
+        }
+        let mut bytes = [0u8; 32];
+        if !value.is_empty() {
+            bytes[1] = value.len() as u8;
+            bytes[32 - value.len()..].copy_from_slice(value);
+        }
+        let s = Option::<Scalar>::from(Scalar::from_be_bytes(&bytes))
+            .ok_or(Error::InvalidClaimData("scalar claim is not byte data"))?;
+        Ok(Self::from(s))
+    }
+
+    pub fn decode_to_bytes(&self) -> CredxResult<Vec<u8>> {
+        let data = self.value.to_be_bytes();
+        let len = data[1] as usize;
+        Ok(data[32 - len..].to_vec())
     }
 }
 

--- a/src/mapping/map_presentation.rs
+++ b/src/mapping/map_presentation.rs
@@ -152,6 +152,7 @@ fn create_presentation<S: ShortGroupSignatureScheme>(
         id: random_string(16, thread_rng()),
         reference_id: sig_st.id.clone(),
         claim: 0,
+        allow_message_decryption: false,
     };
     let range_st = RangeStatement {
         id: random_string(16, thread_rng()),

--- a/src/presentation/verifiable_encryption.rs
+++ b/src/presentation/verifiable_encryption.rs
@@ -1,9 +1,11 @@
 use crate::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
-use crate::presentation::{PresentationBuilder, PresentationProofs};
+use crate::prelude::Ciphertext;
+use crate::presentation::{ByteProof, PresentationBuilder, PresentationProofs};
 use crate::statement::VerifiableEncryptionStatement;
 use crate::CredxResult;
 use blsful::inner_types::{G1Projective, Scalar};
 use blsful::{Bls12381G2Impl, SecretKey};
+use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
 use elliptic_curve::ff::Field;
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
@@ -16,16 +18,21 @@ pub(crate) struct VerifiableEncryptionBuilder<'a> {
     pub(crate) statement: &'a VerifiableEncryptionStatement<G1Projective>,
     pub(crate) b: Scalar,
     pub(crate) r: Scalar,
+    pub(crate) decryptable_builder: Option<VerifiableEncryptionDecryptableBuilder>,
 }
 
 impl<S: ShortGroupSignatureScheme> PresentationBuilder<S> for VerifiableEncryptionBuilder<'_> {
     fn gen_proof(self, challenge: Scalar) -> PresentationProofs<S> {
         let blinder_proof = self.r + challenge * self.b;
+        let decryptable_scalar_proof = self
+            .decryptable_builder
+            .map(|b| b.gen_proof(self.statement, challenge));
         VerifiableEncryptionProof {
             id: self.statement.id.clone(),
             c1: self.c1,
             c2: self.c2,
             blinder_proof,
+            decryptable_scalar_proof,
         }
         .into()
     }
@@ -54,13 +61,136 @@ impl<'a> VerifiableEncryptionBuilder<'a> {
         transcript.append_message(b"r1", r1.to_compressed().as_slice());
         transcript.append_message(b"r2", r2.to_compressed().as_slice());
 
+        let decryptable_builder = if statement.allow_message_decryption {
+            Some(VerifiableEncryptionDecryptableBuilder::commit(
+                statement, message, b, rng, transcript,
+            ))
+        } else {
+            None
+        };
+
         Ok(Self {
             c1,
             c2,
             statement,
             b,
             r,
+            decryptable_builder,
         })
+    }
+}
+
+pub(crate) struct VerifiableEncryptionDecryptableBuilder {
+    pub(crate) message_bytes: [u8; 32],
+    pub(crate) byte_blinders: [Scalar; 32],
+    pub(crate) blinder_blinders: [Scalar; 32],
+    pub(crate) byte_ciphertext: Ciphertext,
+}
+
+impl VerifiableEncryptionDecryptableBuilder {
+    pub fn commit(
+        statement: &VerifiableEncryptionStatement<G1Projective>,
+        message: Scalar,
+        blinder: Scalar,
+        mut rng: impl RngCore + CryptoRng,
+        transcript: &mut Transcript,
+    ) -> Self {
+        let message_bytes = message.to_be_bytes();
+        let mut byte_ciphertext = Ciphertext::default();
+        let mut byte_blinders = [Scalar::ZERO; 32];
+        let mut blinder_blinders = [Scalar::ZERO; 32];
+
+        let shift = Scalar::from(256u16);
+        let mut sum = Scalar::ZERO;
+        let mut power = 31;
+        for i in 0..31 {
+            let b = Scalar::random(&mut rng);
+            sum += b * shift.pow([power as u64]);
+            byte_blinders[i] = b;
+            blinder_blinders[i] = Scalar::random(&mut rng);
+
+            byte_ciphertext.c1[i] = G1Projective::GENERATOR * b;
+            byte_ciphertext.c2[i] = statement.message_generator * Scalar::from(message_bytes[i])
+                + statement.encryption_key.0 * b;
+            power -= 1;
+        }
+        byte_blinders[31] = blinder - sum;
+        blinder_blinders[31] = Scalar::random(&mut rng);
+        byte_ciphertext.c1[31] = G1Projective::GENERATOR * byte_blinders[31];
+        byte_ciphertext.c2[31] = statement.message_generator * Scalar::from(message_bytes[31])
+            + statement.encryption_key.0 * byte_blinders[31];
+
+        for i in 0..message_bytes.len() {
+            transcript.append_u64(
+                b"verifiable_encryption_decryptable_message_byte_index",
+                i as u64,
+            );
+            transcript.append_message(
+                b"byte_proof_c1",
+                byte_ciphertext.c1[i].to_compressed().as_slice(),
+            );
+            transcript.append_message(
+                b"byte_proof_c2",
+                byte_ciphertext.c2[i].to_compressed().as_slice(),
+            );
+            let inner_r1 = G1Projective::GENERATOR * blinder_blinders[i];
+            let inner_r2 = statement.message_generator * byte_blinders[i]
+                + statement.encryption_key.0 * blinder_blinders[i];
+
+            transcript.append_message(b"byte_proof_r1", inner_r1.to_compressed().as_slice());
+            transcript.append_message(b"byte_proof_r2", inner_r2.to_compressed().as_slice());
+        }
+        Self {
+            message_bytes,
+            byte_blinders,
+            blinder_blinders,
+            byte_ciphertext,
+        }
+    }
+
+    pub fn gen_proof(
+        self,
+        statement: &VerifiableEncryptionStatement<G1Projective>,
+        challenge: Scalar,
+    ) -> DecryptableScalarProof {
+        let bp_gens = BulletproofGens::new(8, self.message_bytes.len());
+        let pedersen_gen = PedersenGens {
+            B: statement.message_generator,
+            B_blinding: statement.encryption_key.0,
+        };
+
+        let mut transcript = Transcript::new(b"PresentationEncryptionDecryption byte range proof");
+        transcript.append_message(b"challenge", &challenge.to_be_bytes());
+        let key_segments = self
+            .message_bytes
+            .iter()
+            .map(|b| *b as u64)
+            .collect::<Vec<_>>();
+        let (range_proof, _) = RangeProof::prove_multiple(
+            &bp_gens,
+            &pedersen_gen,
+            &mut transcript,
+            &key_segments,
+            &self.byte_blinders,
+            8,
+        )
+        .expect("range proof to work");
+        let mut byte_proofs = [ByteProof::default(); 32];
+        for ((byte_proof, byte_blinder), (message_byte, blinder_blinder)) in byte_proofs
+            .iter_mut()
+            .zip(self.byte_blinders.iter())
+            .zip(self.message_bytes.iter().zip(self.blinder_blinders.iter()))
+        {
+            *byte_proof = ByteProof {
+                message: byte_blinder + challenge * Scalar::from(*message_byte),
+                blinder: blinder_blinder + challenge * byte_blinder,
+            };
+        }
+        DecryptableScalarProof {
+            byte_proofs,
+            range_proof,
+            byte_ciphertext: self.byte_ciphertext,
+        }
     }
 }
 
@@ -75,6 +205,8 @@ pub struct VerifiableEncryptionProof {
     pub c2: G1Projective,
     /// The schnorr blinder proof
     pub blinder_proof: Scalar,
+    /// The decryptable scalar proof if message decryption is allowed
+    pub decryptable_scalar_proof: Option<DecryptableScalarProof>,
 }
 
 impl VerifiableEncryptionProof {
@@ -83,4 +215,48 @@ impl VerifiableEncryptionProof {
     pub fn decrypt(&self, key: &SecretKey<Bls12381G2Impl>) -> G1Projective {
         self.c2 - self.c1 * key.0
     }
+
+    pub fn decrypt_scalar(&self, key: &SecretKey<Bls12381G2Impl>) -> Option<Scalar> {
+        use rayon::prelude::*;
+
+        if let Some(decryptable_proof) = self.decryptable_scalar_proof.as_ref() {
+            let mut scalar_be_bytes = [0u8; 32];
+            scalar_be_bytes
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, b)| {
+                    let vi = decryptable_proof.byte_ciphertext.c2[i]
+                        - decryptable_proof.byte_ciphertext.c1[i] * key.0;
+
+                    for ki in 0u8..=255 {
+                        let si = Scalar::from(ki);
+                        if vi == G1Projective::GENERATOR * si {
+                            *b = ki;
+                            return;
+                        }
+                    }
+                });
+            let value = Option::<Scalar>::from(Scalar::from_be_bytes(&scalar_be_bytes))?;
+            if self.c2 - self.c1 * key.0 == G1Projective::GENERATOR * value {
+                return Some(value);
+            }
+        }
+        None
+    }
+}
+
+/// A decryptable scalar proof
+///
+/// This proof is only available if the statement allows message decryption
+/// but allows the scalar to be decrypted in a verifiable way.
+///
+/// Useful if the scalar represents a meaningful value
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecryptableScalarProof {
+    /// The byte proofs
+    pub byte_proofs: [ByteProof; 32],
+    /// The range proof
+    pub range_proof: RangeProof,
+    /// The byte ciphertext
+    pub byte_ciphertext: Ciphertext,
 }

--- a/src/statement/verifiable_encryption.rs
+++ b/src/statement/verifiable_encryption.rs
@@ -25,6 +25,8 @@ pub struct VerifiableEncryptionStatement<P: Group + GroupEncoding + Serialize + 
     pub reference_id: String,
     /// The claim index in the other statement
     pub claim: usize,
+    /// Whether to allow message decryption
+    pub allow_message_decryption: bool,
 }
 
 impl<P: Group + GroupEncoding + DeserializeOwned + Serialize> Statement
@@ -41,6 +43,10 @@ impl<P: Group + GroupEncoding + DeserializeOwned + Serialize> Statement
     fn add_challenge_contribution(&self, transcript: &mut Transcript) {
         transcript.append_message(b"statement type", b"el-gamal verifiable encryption");
         transcript.append_message(b"statement id", self.id.as_bytes());
+        transcript.append_u64(
+            b"allow message decryption",
+            self.allow_message_decryption as u64,
+        );
         transcript.append_message(b"reference statement id", self.reference_id.as_bytes());
         transcript.append_message(b"claim index", &Uint::from(self.claim).to_vec());
         transcript.append_message(

--- a/src/verifier/verifiable_encryption.rs
+++ b/src/verifier/verifiable_encryption.rs
@@ -1,8 +1,10 @@
+use crate::error::Error;
 use crate::presentation::VerifiableEncryptionProof;
 use crate::statement::VerifiableEncryptionStatement;
 use crate::verifier::ProofVerifier;
 use crate::CredxResult;
 use blsful::inner_types::{G1Projective, Scalar};
+use bulletproofs::{BulletproofGens, PedersenGens};
 use elliptic_curve::group::Curve;
 use merlin::Transcript;
 
@@ -29,10 +31,77 @@ impl ProofVerifier for VerifiableEncryptionVerifier<'_, '_> {
         transcript.append_message(b"c2", self.proof.c2.to_affine().to_compressed().as_slice());
         transcript.append_message(b"r1", r1.to_affine().to_compressed().as_slice());
         transcript.append_message(b"r2", r2.to_affine().to_compressed().as_slice());
+
+        if let Some(decryptable_proof) = self.proof.decryptable_scalar_proof.as_ref() {
+            for i in 0..decryptable_proof.byte_proofs.len() {
+                transcript.append_u64(
+                    b"verifiable_encryption_decryptable_message_byte_index",
+                    i as u64,
+                );
+
+                transcript.append_message(
+                    b"byte_proof_c1",
+                    decryptable_proof.byte_ciphertext.c1[i]
+                        .to_compressed()
+                        .as_slice(),
+                );
+                transcript.append_message(
+                    b"byte_proof_c2",
+                    decryptable_proof.byte_ciphertext.c2[i]
+                        .to_compressed()
+                        .as_slice(),
+                );
+                let inner_r1 = decryptable_proof.byte_ciphertext.c1[i] * challenge
+                    + G1Projective::GENERATOR * decryptable_proof.byte_proofs[i].blinder;
+                let inner_r2 = decryptable_proof.byte_ciphertext.c2[i] * challenge
+                    + self.statement.encryption_key.0 * decryptable_proof.byte_proofs[i].blinder
+                    + self.statement.message_generator * decryptable_proof.byte_proofs[i].message;
+
+                transcript.append_message(b"byte_proof_r1", inner_r1.to_compressed().as_slice());
+                transcript.append_message(b"byte_proof_r2", inner_r2.to_compressed().as_slice());
+            }
+        }
+
         Ok(())
     }
 
-    fn verify(&self, _challenge: Scalar) -> CredxResult<()> {
+    fn verify(&self, challenge: Scalar) -> CredxResult<()> {
+        if let Some(decryptable_proof) = self.proof.decryptable_scalar_proof.as_ref() {
+            let bp_gens = BulletproofGens::new(8, decryptable_proof.byte_proofs.len());
+            let pedersen_gen = PedersenGens {
+                B: self.statement.message_generator,
+                B_blinding: self.statement.encryption_key.0,
+            };
+
+            let mut transcript =
+                Transcript::new(b"PresentationEncryptionDecryption byte range proof");
+            transcript.append_message(b"challenge", &challenge.to_be_bytes());
+            // Prove each byte is in the range [0, 255]
+            decryptable_proof
+                .range_proof
+                .verify_multiple(
+                    &bp_gens,
+                    &pedersen_gen,
+                    &mut transcript,
+                    &decryptable_proof.byte_ciphertext.c2,
+                    8,
+                )
+                .map_err(|_| Error::General("Range proof verification failed"))?;
+
+            let shift = Scalar::from(256u16);
+            let mut sum = G1Projective::IDENTITY;
+
+            for c2 in &decryptable_proof.byte_ciphertext.c2 {
+                sum *= shift;
+                sum += c2;
+            }
+
+            if sum != self.proof.c2 {
+                return Err(Error::General(
+                    "Sum of byte ciphertexts does not match the ciphertext",
+                ));
+            }
+        }
         Ok(())
     }
 }

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -362,7 +362,7 @@ fn presentation_decrypt_scalar_claim() {
     presentation.verify(&presentation_schema, &nonce).unwrap();
 
     if let PresentationProofs::VerifiableEncryption(verenc) = &presentation.proofs[&verenc1_id] {
-        // This works because the phone number is a less than 32 bytes
+        // This works because the name is less than 32 bytes
         let decrypted_name_scalar = verenc
             .decrypt_scalar(&issuer.verifiable_decryption_key)
             .unwrap();

--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -127,6 +127,7 @@ fn test_presentation_1_credential_works() -> CredxResult<()> {
         id: random_string(16, rand::thread_rng()),
         reference_id: sig_st.id.clone(),
         claim: 0,
+        allow_message_decryption: false,
     };
     let range_st = RangeStatement {
         id: random_string(16, thread_rng()),
@@ -266,6 +267,126 @@ fn presentation_decrypt_claim_works() {
 }
 
 #[test]
+fn presentation_decrypt_scalar_claim() {
+    const CRED_ID: &str = "91742856-6eda-45fb-a709-d22ebb5ec8a5";
+    let schema_claims = [
+        ClaimSchema {
+            claim_type: ClaimType::Revocation,
+            label: "identifier".to_string(),
+            print_friendly: false,
+            validators: vec![],
+        },
+        ClaimSchema {
+            claim_type: ClaimType::Scalar,
+            label: "name".to_string(),
+            print_friendly: true,
+            validators: vec![],
+        },
+        ClaimSchema {
+            claim_type: ClaimType::Hashed,
+            label: "address".to_string(),
+            print_friendly: true,
+            validators: vec![ClaimValidator::Length {
+                min: None,
+                max: Some(u8::MAX as usize),
+            }],
+        },
+        ClaimSchema {
+            claim_type: ClaimType::Number,
+            label: "phone-number".to_string(),
+            print_friendly: true,
+            validators: vec![ClaimValidator::Range {
+                min: Some(0),
+                max: None,
+            }],
+        },
+    ];
+    let cred_schema = CredentialSchema::new(Some("Test"), Some(""), &[], &schema_claims).unwrap();
+    let (issuer_public, mut issuer) = Issuer::<BbsScheme>::new(&cred_schema);
+    let credential = issuer
+        .sign_credential(&[
+            RevocationClaim::from(CRED_ID).into(),
+            ScalarClaim::encode_str("John Doe").unwrap().into(),
+            HashedClaim::from("P Sherman 42 Wallaby Way Sydney").into(),
+            NumberClaim::from(8018881111i64).into(),
+        ])
+        .unwrap();
+
+    let sig_st = SignatureStatement {
+        disclosed: BTreeSet::new(),
+        id: random_string(16, thread_rng()),
+        issuer: issuer_public.clone(),
+    };
+    let acc_st = RevocationStatement {
+        id: random_string(16, thread_rng()),
+        reference_id: sig_st.id.clone(),
+        accumulator: issuer_public.revocation_registry,
+        verification_key: issuer_public.revocation_verifying_key,
+        claim: 0,
+    };
+    let verenc_st1 = VerifiableEncryptionStatement {
+        message_generator: G1Projective::GENERATOR,
+        encryption_key: issuer_public.verifiable_encryption_key,
+        id: random_string(16, thread_rng()),
+        reference_id: sig_st.id.clone(),
+        claim: 1,
+        allow_message_decryption: true,
+    };
+    let verenc_st2 = VerifiableEncryptionStatement {
+        message_generator: G1Projective::GENERATOR,
+        encryption_key: issuer_public.verifiable_encryption_key,
+        id: random_string(16, thread_rng()),
+        reference_id: sig_st.id.clone(),
+        claim: 3,
+        allow_message_decryption: true,
+    };
+
+    let verenc1_id = verenc_st1.id.clone();
+    let verenc2_id = verenc_st2.id.clone();
+    let mut nonce = [0u8; 16];
+    thread_rng().fill_bytes(&mut nonce);
+
+    let credentials = indexmap! { sig_st.id.clone() => credential.credential.into() };
+
+    let presentation_schema = PresentationSchema::new(&[
+        sig_st.into(),
+        acc_st.into(),
+        verenc_st1.into(),
+        verenc_st2.into(),
+    ]);
+
+    let presentation = Presentation::create(&credentials, &presentation_schema, &nonce).unwrap();
+    presentation.verify(&presentation_schema, &nonce).unwrap();
+    let proof_data = serde_bare::to_vec(&presentation).unwrap();
+    let presentation: Presentation<BbsScheme> = serde_bare::from_slice(&proof_data).unwrap();
+    presentation.verify(&presentation_schema, &nonce).unwrap();
+
+    if let PresentationProofs::VerifiableEncryption(verenc) = &presentation.proofs[&verenc1_id] {
+        // This works because the phone number is a less than 32 bytes
+        let decrypted_name_scalar = verenc
+            .decrypt_scalar(&issuer.verifiable_decryption_key)
+            .unwrap();
+        let decrypted_name = ScalarClaim::from(decrypted_name_scalar)
+            .decode_to_str()
+            .unwrap();
+        assert_eq!(decrypted_name.as_str(), "John Doe");
+    } else {
+        assert!(false, "expected VerifiableEncryptionDecryption");
+    }
+
+    if let PresentationProofs::VerifiableEncryption(verenc) = &presentation.proofs[&verenc2_id] {
+        // This works because the phone number is a less than 32 bytes
+        let decrypted_phone_scalar = verenc
+            .decrypt_scalar(&issuer.verifiable_decryption_key)
+            .unwrap();
+        let decrypted_phone = NumberClaim::from(decrypted_phone_scalar);
+        assert_eq!(decrypted_phone.value, 8018881111);
+    } else {
+        assert!(false, "expected VerifiableEncryptionDecryption");
+    }
+}
+
+#[test]
 fn presentation_with_domain_proof() {
     const LABEL: &str = "Test Schema";
     const DESCRIPTION: &str = "This is a test presentation schema";
@@ -360,6 +481,7 @@ fn presentation_with_domain_proof() {
         id: random_string(16, rand::thread_rng()),
         reference_id: sig_st.id.clone(),
         claim: 0,
+        allow_message_decryption: false,
     };
     let verenc_st_id = verenc_st.id.clone();
     let range_st = RangeStatement {
@@ -520,6 +642,7 @@ fn test_presentation_1_credential_alter_revealed_message_fails() -> CredxResult<
         id: random_string(16, rand::thread_rng()),
         reference_id: sig_st.id.clone(),
         claim: 0,
+        allow_message_decryption: false,
     };
     let range_st = RangeStatement {
         id: random_string(16, rand::thread_rng()),

--- a/tests/real-id.rs
+++ b/tests/real-id.rs
@@ -242,6 +242,7 @@ fn create_bank_statement_statements_for_realid<S: ShortGroupSignatureScheme>(
         message_generator: G1Projective::GENERATOR,
         encryption_key: bank_public.verifiable_encryption_key,
         claim: schema.claim_indices.get_index_of("account_number").unwrap(),
+        allow_message_decryption: false,
     };
 
     let bank_statement_statements: [Statements<S>; 5] = [
@@ -367,6 +368,7 @@ fn create_dos_passport_statements_for_realid<S: ShortGroupSignatureScheme>(
             .claim_indices
             .get_index_of("passport_number")
             .unwrap(),
+        allow_message_decryption: false,
     };
 
     let dos_passport_statements: [Statements<S>; 7] = [
@@ -408,6 +410,7 @@ fn create_soc_sec_statements_for_realid<S: ShortGroupSignatureScheme>(
         message_generator: G1Projective::GENERATOR,
         encryption_key: ssa_public.verifiable_encryption_key,
         claim: schema.claim_indices.get_index_of("soc_sec_number").unwrap(),
+        allow_message_decryption: false,
     };
 
     let soc_sec_statements: [Statements<S>; 3] = [


### PR DESCRIPTION
This feature allows decrypting the raw scalar value for verifiable encryption. The test added demos the following:

- Shows that when enabled the encrypted scalar can be recovered
- Shows how a value that is less than 30 bytes like a string or byte sequence or number can be stored this way.
- Shows how they can be verifiably decrypted.
@mark-moir I believe this is more what you are looking for.